### PR TITLE
Fix for Scale9 color tinting and smoothing.

### DIFF
--- a/source/feathers/display/Scale3Image.as
+++ b/source/feathers/display/Scale3Image.as
@@ -419,6 +419,8 @@ package feathers.display
 						{
 							image = helperImage;
 							helperImage.texture = this._textures.first;
+							helperImage.smoothing = this._smoothing;
+							helperImage.color = this._color;
 							helperImage.readjustSize();
 						}
 						else
@@ -440,6 +442,8 @@ package feathers.display
 						{
 							image = helperImage;
 							helperImage.texture = this._textures.second;
+							helperImage.smoothing = this._smoothing;
+							helperImage.color = this._color;
 							helperImage.readjustSize();
 						}
 						else
@@ -461,6 +465,8 @@ package feathers.display
 						{
 							image = helperImage;
 							helperImage.texture = this._textures.third;
+							helperImage.smoothing = this._smoothing;
+							helperImage.color = this._color;
 							helperImage.readjustSize();
 						}
 						else
@@ -493,6 +499,8 @@ package feathers.display
 						{
 							image = helperImage;
 							helperImage.texture = this._textures.first;
+							helperImage.smoothing = this._smoothing;
+							helperImage.color = this._color;
 							helperImage.readjustSize();
 						}
 						else
@@ -514,6 +522,8 @@ package feathers.display
 						{
 							image = helperImage;
 							helperImage.texture = this._textures.second;
+							helperImage.smoothing = this._smoothing;
+							helperImage.color = this._color;
 							helperImage.readjustSize();
 						}
 						else
@@ -535,6 +545,8 @@ package feathers.display
 						{
 							image = helperImage;
 							helperImage.texture = this._textures.third;
+							helperImage.smoothing = this._smoothing;
+							helperImage.color = this._color;
 							helperImage.readjustSize();
 						}
 						else

--- a/source/feathers/display/Scale9Image.as
+++ b/source/feathers/display/Scale9Image.as
@@ -466,6 +466,8 @@ package feathers.display
 					{
 						image = helperImage;
 						helperImage.texture = this._textures.topLeft;
+						helperImage.smoothing = this._smoothing;
+						helperImage.color = this._color;
 						helperImage.readjustSize();
 					}
 					else
@@ -486,6 +488,8 @@ package feathers.display
 					{
 						image = helperImage;
 						helperImage.texture = this._textures.topCenter;
+						helperImage.smoothing = this._smoothing;
+						helperImage.color = this._color;
 						helperImage.readjustSize();
 					}
 					else
@@ -507,6 +511,8 @@ package feathers.display
 					{
 						image = helperImage;
 						helperImage.texture = this._textures.topRight;
+						helperImage.smoothing = this._smoothing;
+						helperImage.color = this._color;
 						helperImage.readjustSize();
 					}
 					else
@@ -530,6 +536,8 @@ package feathers.display
 					{
 						image = helperImage;
 						helperImage.texture = this._textures.middleLeft;
+						helperImage.smoothing = this._smoothing;
+						helperImage.color = this._color;
 						helperImage.readjustSize();
 					}
 					else
@@ -551,6 +559,8 @@ package feathers.display
 					{
 						image = helperImage;
 						helperImage.texture = this._textures.middleCenter;
+						helperImage.smoothing = this._smoothing;
+						helperImage.color = this._color;
 						helperImage.readjustSize();
 					}
 					else
@@ -573,6 +583,8 @@ package feathers.display
 					{
 						image = helperImage;
 						helperImage.texture = this._textures.middleRight;
+						helperImage.smoothing = this._smoothing;
+						helperImage.color = this._color;
 						helperImage.readjustSize();
 					}
 					else
@@ -597,6 +609,8 @@ package feathers.display
 					{
 						image = helperImage;
 						helperImage.texture = this._textures.bottomLeft;
+						helperImage.smoothing = this._smoothing;
+						helperImage.color = this._color;
 						helperImage.readjustSize();
 					}
 					else
@@ -617,6 +631,8 @@ package feathers.display
 					{
 						image = helperImage;
 						helperImage.texture = this._textures.bottomCenter;
+						helperImage.smoothing = this._smoothing;
+						helperImage.color = this._color;
 						helperImage.readjustSize();
 					}
 					else
@@ -638,6 +654,8 @@ package feathers.display
 					{
 						image = helperImage;
 						helperImage.texture = this._textures.bottomRight;
+						helperImage.smoothing = this._smoothing;
+						helperImage.color = this._color;
 						helperImage.readjustSize();
 					}
 					else


### PR DESCRIPTION
Color and smoothing were not being applied to the helper image after latest changes.
