### PR TITLE
Fixed an issue with the Vertical- and HorizontalLayout

### DIFF
--- a/source/feathers/layout/HorizontalLayout.as
+++ b/source/feathers/layout/HorizontalLayout.as
@@ -481,8 +481,8 @@ package feathers.layout
 		 */
 		public function layout(items:Vector.<DisplayObject>, suggestedBounds:ViewPortBounds = null, result:LayoutBoundsResult = null):LayoutBoundsResult
 		{
-			const scrollX:Number = suggestedBounds.scrollX;
-			const scrollY:Number = suggestedBounds.scrollY;
+			const scrollX:Number = suggestedBounds ? suggestedBounds.scrollX : 0;
+			const scrollY:Number = suggestedBounds ? suggestedBounds.scrollY : 0;
 			const boundsX:Number = suggestedBounds ? suggestedBounds.x : 0;
 			const boundsY:Number = suggestedBounds ? suggestedBounds.y : 0;
 			const minWidth:Number = suggestedBounds ? suggestedBounds.minWidth : 0;

--- a/source/feathers/layout/VerticalLayout.as
+++ b/source/feathers/layout/VerticalLayout.as
@@ -484,8 +484,8 @@ package feathers.layout
 		 */
 		public function layout(items:Vector.<DisplayObject>, viewPortBounds:ViewPortBounds = null, result:LayoutBoundsResult = null):LayoutBoundsResult
 		{
-			const scrollX:Number = viewPortBounds.scrollX;
-			const scrollY:Number = viewPortBounds.scrollY;
+			const scrollX:Number = viewPortBounds ? viewPortBounds.scrollX : 0;
+			const scrollY:Number = viewPortBounds ? viewPortBounds.scrollY : 0;
 			const boundsX:Number = viewPortBounds ? viewPortBounds.x : 0;
 			const boundsY:Number = viewPortBounds ? viewPortBounds.y : 0;
 			const minWidth:Number = viewPortBounds ? viewPortBounds.minWidth : 0;


### PR DESCRIPTION
`scrollX` and `scrollY` should be set just as all the other parameters (by checking if the viewport parameter is `null`).
