### PR TITLE
MetalWorksMobileTheme: Change prompt textFormat

### DIFF
--- a/themes/MetalWorksMobileTheme/source/feathers/themes/MetalWorksMobileTheme.as
+++ b/themes/MetalWorksMobileTheme/source/feathers/themes/MetalWorksMobileTheme.as
@@ -1154,7 +1154,7 @@ package feathers.themes
 			input.textEditorProperties.fontSize = 24 * this.scale;
 			input.textEditorProperties.color = LIGHT_TEXT_COLOR;
 
-			input.promptProperties.textFormat = this.smallLightTextFormat;
+			input.promptProperties.textFormat = this.smallDisabledTextFormat;
 			input.promptProperties.embedFonts = true;
 		}
 


### PR DESCRIPTION
text and prompt have the same textFormat, it's confusing

Prompt | Some Text

before (looks like "Message" is a text in input field, but it is not):
![prompt_before](https://f.cloud.github.com/assets/228802/1122690/b2f1e0f8-1ae1-11e3-952e-8b3f11944931.png)

after:
![prompt_after](https://f.cloud.github.com/assets/228802/1122691/b52dda8e-1ae1-11e3-8a6f-a06f608a8d0d.png)
