### PR TITLE
BaseDefaultItemRenderer clears label, icon or accessory when flags are false

### DIFF
--- a/source/feathers/controls/renderers/BaseDefaultItemRenderer.as
+++ b/source/feathers/controls/renderers/BaseDefaultItemRenderer.as
@@ -2016,6 +2016,18 @@ package feathers.controls.renderers
 		 */
 		protected function commitData():void
 		{
+			if(!this._itemHasLabel)
+			{
+				this._label = "";
+			}
+			if(!this._itemHasIcon)
+			{
+				this.replaceIcon(null);
+			}
+			if(!this._itemHasAccessory)
+			{
+				this.replaceAccessory(null);
+			}
 			if(this._data && this._owner)
 			{
 				if(this._itemHasLabel)


### PR DESCRIPTION
Does it when flags _itemHasLabel\Icon\Accessory set to false
