### PR TITLE
Fixed occasional null reference bug

### DIFF
--- a/source/feathers/controls/text/TextFieldTextEditor.as
+++ b/source/feathers/controls/text/TextFieldTextEditor.as
@@ -642,11 +642,14 @@ package feathers.controls.text
 						else
 						{
 							const bounds:Rectangle = this.textField.getCharBoundaries(this._pendingSelectionStartIndex);
-							const boundsX:Number = bounds.x;
-							if(bounds && (boundsX + bounds.width - positionX) < (positionX - boundsX))
-							{
-								this._pendingSelectionStartIndex++;
-							}
+                                                        if (bounds) 
+                                                        {
+                                                            const boundsX:Number = bounds.x;
+                                                            if((boundsX + bounds.width - positionX) < (positionX - boundsX))
+                                                            {
+                                                                    this._pendingSelectionStartIndex++;
+                                                            }
+                                                        }
 						}
 						this._pendingSelectionEndIndex = this._pendingSelectionStartIndex;
 					}


### PR DESCRIPTION
After frantic clicking in and out of a text editor, I'm able to occasionally raise a null reference error because 'bounds.x' isn't defined and not being caught.
