### PR TITLE
Fix a memory leak

### DIFF
--- a/source/feathers/controls/Scroller.as
+++ b/source/feathers/controls/Scroller.as
@@ -2391,6 +2391,11 @@ package feathers.controls
 		{
 			Starling.current.nativeStage.removeEventListener(MouseEvent.MOUSE_WHEEL, nativeStage_mouseWheelHandler);
 			Starling.current.nativeStage.removeEventListener("orientationChange", nativeStage_orientationChangeHandler);
+
+			var exclusiveTouch:ExclusiveTouch = ExclusiveTouch.forStage(this.stage);
+			if(exclusiveTouch) {
+				exclusiveTouch.removeEventListener(Event.CHANGE, exclusiveTouch_changeHandler);
+			}
 			super.dispose();
 		}
 


### PR DESCRIPTION
Hello, we had some trouble with the garbage collector.
In some cases the listener on the ExclusiveTouch is not removed.
In the case of a scroll container (in INTERACTION_MODE_TOUCH the default value for interactionMode) with SCROLL_POLICY_OFF that contains a button that trigers a change of the current screen to a new one (disposing the scrollContainer), the scroll container would never go into the stage_touchHandler() / TouchPhase.ENDED event and would not remove the exclusive touch listener ExclusiveTouch.forStage(this.stage).removeEventListener(Event.CHANGE, exclusiveTouch_changeHandler);

I hope that helps,
you might ask why we use scrollcontainers with no scroll, it's just for the background option and its ease of using slice9images.
