### PR TITLE
Make sure to remove the correct overlay from _popUpToOverlay

### DIFF
--- a/source/feathers/core/DefaultPopUpManager.as
+++ b/source/feathers/core/DefaultPopUpManager.as
@@ -281,11 +281,11 @@ package feathers.core
 			if(overlay)
 			{
 				//this is a temporary workaround for Starling issue #131
+				delete _popUpToOverlay[popUp];
 				this._root.stage.addEventListener(EnterFrameEvent.ENTER_FRAME, function(event:EnterFrameEvent):void
 				{
 					event.currentTarget.removeEventListener(event.type, arguments.callee);
 					overlay.removeFromParent(true);
-					delete _popUpToOverlay[popUp];
 				});
 			}
 			var focusManager:IFocusManager = this._popUpToFocusManager[popUp];


### PR DESCRIPTION
Currently the popup manager leaves an orphaned overlay when a popup is closed and the opened again in the same frame. This change fixes that by maintaining the overlay dictionary when the popup is removed and not at a later time.
