### PR TITLE
Remove smoothing which appears when popup places at fractional coordinates.

### DIFF
--- a/source/feathers/core/DefaultPopUpManager.as
+++ b/source/feathers/core/DefaultPopUpManager.as
@@ -245,8 +245,8 @@ package feathers.core
 			{
 				IValidating(popUp).validate();
 			}
-			popUp.x = (stage.stageWidth - popUp.width) / 2;
-			popUp.y = (stage.stageHeight - popUp.height) / 2;
+			popUp.x = stage.stageWidth - popUp.width >> 1;
+			popUp.y = stage.stageHeight - popUp.height >> 1;
 		}
 
 		/**


### PR DESCRIPTION
Floor popup's coordinates after center, to remove DO (display object) smoothing, that applies if DO have placed in fractional coordinates.
