### PR TITLE
Fix list height of DropDownPopUpContentManager

### DIFF
--- a/source/feathers/controls/popups/DropDownPopUpContentManager.as
+++ b/source/feathers/controls/popups/DropDownPopUpContentManager.as
@@ -131,9 +131,11 @@ package feathers.controls.popups
 			{
 				IValidating(this.source).validate();
 			}
-			if(this.content is IFeathersControl)
+
+			const uiContent:IFeathersControl = IFeathersControl(this.content);
+
+			if(uiContent)
 			{
-				const uiContent:IFeathersControl = IFeathersControl(this.content);
 				uiContent.minWidth = Math.max(uiContent.minWidth, this.source.width);
 				uiContent.validate();
 			}
@@ -167,7 +169,14 @@ package feathers.controls.popups
 			}
 			
 			//set the height of the list to the available space
-			this.content.height = Starling.current.stage.stageHeight - (globalOrigin.y + globalOrigin.height);
+			if(uiContent)
+			{
+				uiContent.maxHeight = Math.min(uiContent.maxHeight, Starling.current.stage.stageHeight - (globalOrigin.y + globalOrigin.height));
+			}
+			else
+			{
+				this.content.height = Starling.current.stage.stageHeight - (globalOrigin.y + globalOrigin.height);
+			}
 		}
 
 		/**


### PR DESCRIPTION
Hello Josh,

I noticed an issue using PickerList & DropDownPopUpManager when the list is taller than the available space, it's height is not limited to the available space automatically.
I checked the others IPopUpContentManager and they dont have this issue so I fixed it in the DropDownPopUpContentManager.

I hope you'll accept this patch :)
