### PR TITLE
Scroller: minor documentation errors

### DIFF
--- a/source/feathers/controls/Scroller.as
+++ b/source/feathers/controls/Scroller.as
@@ -438,8 +438,8 @@ package feathers.controls
 		/**
 		 * The value added to the <code>nameList</code> of the vertical scroll
 		 * bar. This variable is <code>protected</code> so that sub-classes can
-		 * customize the horizontal scroll bar name in their constructors
-		 * instead of using the default name defined by <code>DEFAULT_CHILD_NAME_HORIZONTAL_SCROLL_BAR</code>.
+		 * customize the vertical scroll bar name in their constructors
+		 * instead of using the default name defined by <code>DEFAULT_CHILD_NAME_VERTICAL_SCROLL_BAR</code>.
 		 *
 		 * <p>To customize the vertical scroll bar name without subclassing, see
 		 * <code>customVerticalScrollBarName</code>.</p>
@@ -1496,7 +1496,7 @@ package feathers.controls
 		 * <p>In the following example, vertical scrolling is disabled:</p>
 		 *
 		 * <listing version="3.0">
-		 * scroller.horizontalScrollPolicy = Scroller.SCROLL_POLICY_OFF;</listing>
+		 * scroller.verticalScrollPolicy = Scroller.SCROLL_POLICY_OFF;</listing>
 		 *
 		 * @default Scroller.SCROLL_POLICY_AUTO
 		 *


### PR DESCRIPTION
Fixed documentation errors where the **verticalScrollPolicy** and
**verticalScrollBarName** properties reference the horizontal scroll bar
instead of the vertical scroll bar.
