### PR TITLE
Have fix bug when first itemrenderer reset own selection.

### DIFF
--- a/source/feathers/controls/supportClasses/ListDataViewPort.as
+++ b/source/feathers/controls/supportClasses/ListDataViewPort.as
@@ -583,7 +583,9 @@ package feathers.controls.supportClasses
 			}
 			if(basicsInvalid)
 			{
+				this._ignoreSelectionChanges = oldIgnoreSelectionChanges;
 				this.refreshRenderers();
+				this._ignoreSelectionChanges = true;
 			}
 			if(stylesInvalid || basicsInvalid)
 			{


### PR DESCRIPTION
In case if first itemrenderer receive data and select himself, list ignore change event, and reset itemrenderer's selection in 'refreshSelection' method.
