### PR TITLE
Make sure the validation queue does not freeze when an error occurred during validation.

### DIFF
--- a/source/feathers/core/ValidationQueue.as
+++ b/source/feathers/core/ValidationQueue.as
@@ -153,16 +153,19 @@ package feathers.core
 				return;
 			}
 			this._isValidating = true;
-			this._queue = this._queue.sort(queueSortFunction);
-			while(this._queue.length > 0) //rechecking length after the shift
-			{
-				var item:IValidating = this._queue.shift();
-				item.validate();
+			try {
+				this._queue = this._queue.sort(queueSortFunction);
+				while(this._queue.length > 0) //rechecking length after the shift
+				{
+					var item:IValidating = this._queue.shift();
+					item.validate();
+				}
+				const temp:Vector.<IValidating> = this._queue;
+				this._queue = this._delayedQueue;
+				this._delayedQueue = temp;
+			} finally {
+				this._isValidating = false;
 			}
-			const temp:Vector.<IValidating> = this._queue;
-			this._queue = this._delayedQueue;
-			this._delayedQueue = temp;
-			this._isValidating = false;
 		}
 
 		/**


### PR DESCRIPTION
When an exception is thrown during the validation of any item, the validation queue is stopped because `_isValidating` will stay `true` forever.

We show an error dialog to our users when an uncaught exception is thrown. Unfortunately this error dialog is never shown correctly cause it will not be validated in this case.

I added a simple `try..finally` block to the validation queue to prevent this scenario. This way the error is handled the normal way and the next time the validation is triggered it will continue normally with the item that is after the one that caused the error.
