### PR TITLE
Fix of addling listener to Event.REMOVED_FROM_STAGE in DefaultPopUpManager:addPopUp

### DIFF
--- a/source/feathers/core/DefaultPopUpManager.as
+++ b/source/feathers/core/DefaultPopUpManager.as
@@ -161,8 +161,8 @@ package feathers.core
 			}
 
 			this._popUps.push(popUp);
-			this._root.addChild(popUp);
 			popUp.addEventListener(Event.REMOVED_FROM_STAGE, popUp_removedFromStageHandler);
+			this._root.addChild(popUp);
 
 			if(this._popUps.length == 1)
 			{


### PR DESCRIPTION
Event listener should be added before popup is added to stage, because popup may be disposed right after being placed on stage.
