### PR TITLE
Feathers List conflicts with Haxe swc's

### DIFF
--- a/source/feathers/controls/SpinnerList.as
+++ b/source/feathers/controls/SpinnerList.as
@@ -14,7 +14,7 @@ package feathers.controls
 	import feathers.layout.ISpinnerLayout;
 	import feathers.layout.VerticalSpinnerLayout;
 	import feathers.skins.IStyleProvider;
-
+	import feathers.controls.List;
 	import flash.ui.Keyboard;
 
 	import starling.display.DisplayObject;
@@ -54,7 +54,7 @@ package feathers.controls
 	 *
 	 * @see ../../../help/spinner-list.html How to use the Feathers SpinnerList component
 	 */
-	public class SpinnerList extends List
+	public class SpinnerList extends feathers.controls.List
 	{
 		/**
 		 * The default <code>IStyleProvider</code> for all <code>SpinnerList</code>

--- a/source/feathers/controls/renderers/DefaultListItemRenderer.as
+++ b/source/feathers/controls/renderers/DefaultListItemRenderer.as
@@ -321,15 +321,16 @@ package feathers.controls.renderers
 		/**
 		 * @inheritDoc
 		 */
-		public function get owner():List
+		 // changed List to use full package to avoid haxe swc conflicts
+		public function get owner():feathers.controls.List
 		{
-			return List(this._owner);
+			return feathers.controls.List(this._owner);
 		}
 		
 		/**
 		 * @private
 		 */
-		public function set owner(value:List):void
+		public function set owner(value:feathers.controls.List):void
 		{
 			if(this._owner == value)
 			{
@@ -343,7 +344,7 @@ package feathers.controls.renderers
 			this._owner = value;
 			if(this._owner)
 			{
-				var list:List = List(this._owner);
+				var list:feathers.controls.List = feathers.controls.List(this._owner);
 				this.isSelectableWithoutToggle = list.isSelectable;
 				if(list.allowMultipleSelection)
 				{

--- a/source/feathers/controls/renderers/IListItemRenderer.as
+++ b/source/feathers/controls/renderers/IListItemRenderer.as
@@ -8,6 +8,7 @@ accordance with the terms of the accompanying license agreement.
 package feathers.controls.renderers
 {
 	import feathers.controls.*;
+	import feathers.controls.List;
 	import feathers.core.IToggle;
 
 	/**
@@ -73,12 +74,12 @@ package feathers.controls.renderers
 		 *
 		 * <p>This property is set by the list, and should not be set manually.</p>
 		 */
-		function get owner():List;
+		function get owner():import feathers.controls.List;
 		
 		/**
 		 * @private
 		 */
-		function set owner(value:List):void;
+		function set owner(value:import feathers.controls.List):void;
 
 		/**
 		 * The ID of the factory used to create this item renderer.

--- a/source/feathers/controls/supportClasses/ListDataViewPort.as
+++ b/source/feathers/controls/supportClasses/ListDataViewPort.as
@@ -212,12 +212,12 @@ package feathers.controls.supportClasses
 
 		private var _owner:List;
 
-		public function get owner():List
+		public function get owner():import feathers.controls.List
 		{
 			return this._owner;
 		}
 
-		public function set owner(value:List):void
+		public function set owner(value:import feathers.controls.List):void
 		{
 			if(this._owner == value)
 			{


### PR DESCRIPTION
Some Feathers List conflicts with Haxe swc's when using a haxe swc in an as3 project that also uses as3 starling feathers.
Changed 'List' to 'feathers.controls.List'
would prefer "List" renamed to something else but realize that it's probably too late, I can't find any alternative work round on the haxe swc side, so this change would be appreciated so my submodule can still use feathers master.