### PR TITLE
Add leading property to Bitmap fonts

### DIFF
--- a/source/feathers/controls/text/BitmapFontTextRenderer.as
+++ b/source/feathers/controls/text/BitmapFontTextRenderer.as
@@ -660,7 +660,7 @@ package feathers.controls.text
 			{
 				scale = 1;
 			}
-			var lineHeight:Number = font.lineHeight * scale;
+			var lineHeight:Number = font.lineHeight * scale + this.currentTextFormat.leading;
 			var maxLineWidth:Number = this.explicitWidth;
 			if(maxLineWidth !== maxLineWidth) //isNaN
 			{
@@ -693,7 +693,7 @@ package feathers.controls.text
 					}
 					previousCharID = NaN;
 					currentX = 0;
-					currentY += lineHeight;
+					currentY = currentY + lineHeight;
 					startXOfPreviousWord = 0;
 					wordCountForLine = 0;
 					widthOfWhitespaceAfterWord = 0;
@@ -778,7 +778,7 @@ package feathers.controls.text
 			}
 
 			result.x = maxX;
-			result.y = currentY + lineHeight;
+			result.y = currentY + lineHeight - this.currentTextFormat.leading;
 			return result;
 		}
 
@@ -881,7 +881,7 @@ package feathers.controls.text
 			{
 				scale = 1;
 			}
-			var lineHeight:Number = font.lineHeight * scale;
+			var lineHeight:Number = font.lineHeight * scale + this.currentTextFormat.leading;
 
 			var hasExplicitWidth:Boolean = this.explicitWidth === this.explicitWidth; //!isNaN
 			var isAligned:Boolean = this.currentTextFormat.align != TextFormatAlign.LEFT;
@@ -1075,7 +1075,7 @@ package feathers.controls.text
 			this._characterBatch.x = this._batchX;
 
 			result.x = maxX;
-			result.y = currentY + lineHeight;
+			result.y = currentY + lineHeight - this.currentTextFormat.leading;
 			return result;
 		}
 

--- a/source/feathers/text/BitmapFontTextFormat.as
+++ b/source/feathers/text/BitmapFontTextFormat.as
@@ -22,7 +22,7 @@ package feathers.text
 		/**
 		 * Constructor.
 		 */
-		public function BitmapFontTextFormat(font:Object, size:Number = NaN, color:uint = 0xffffff, align:String = TextFormatAlign.LEFT)
+		public function BitmapFontTextFormat(font:Object, size:Number = NaN, color:uint = 0xffffff, align:String = TextFormatAlign.LEFT, leading : Number = 0)
 		{
 			if(font is String)
 			{
@@ -36,6 +36,7 @@ package feathers.text
 			this.size = size;
 			this.color = color;
 			this.align = align;
+			this.leading = leading;
 		}
 
 		/**
@@ -89,7 +90,16 @@ package feathers.text
 		 * @default flash.text.TextFormatAlign.LEFT
 		 */
 		public var align:String = TextFormatAlign.LEFT;
-		
+
+		/**
+		 * A number representing the amount of vertical space (called leading)
+		 * between lines. The total vertical distance between lines is this
+		 * value added to the BitmapFont instance's lineHeight property.
+		 *
+		 * @default 0
+		 */
+		public var leading:Number;
+
 		/**
 		 * Determines if the kerning values defined in the BitmapFont instance
 		 * will be used for layout.


### PR DESCRIPTION
This new property allows to set the line height easily for text created from bitmap fonts.   
We found that we need this property a lot to lay out UIs precisely.   
The other solution (TextFieldRenderer + CSS) is quite buggy, since it inherited Falsh's TextField bugs.