### PR TITLE
Slider: backported new track interaction mode from master

### DIFF
--- a/source/feathers/controls/Slider.as
+++ b/source/feathers/controls/Slider.as
@@ -207,6 +207,16 @@ package feathers.controls
 		public static const TRACK_INTERACTION_MODE_TO_VALUE:String = "toValue";
 
 		/**
+		 * When the track is touched, the slider's thumb jumps directly to the
+		 * touch position, and the slider's <code>value</code> property is
+		 * updated to match as if the thumb were dragged to that position, and
+		 * the thumb may continue to be dragged until the touch ends.
+		 *
+		 * @see #trackInteractionMode
+		 */
+		public static const TRACK_INTERACTION_MODE_TO_VALUE_WITH_DRAG:String = "toValueWithDrag";
+
+		/**
 		 * When the track is touched, the <code>value</code> is increased or
 		 * decreased (depending on the location of the touch) by the value of
 		 * the <code>page</code> property.
@@ -886,7 +896,7 @@ package feathers.controls
 		 */
 		protected var _trackInteractionMode:String = TRACK_INTERACTION_MODE_TO_VALUE;
 
-		[Inspectable(type="String",enumeration="toValue,byPage")]
+		[Inspectable(type="String",enumeration="toValue,toValueWithDrag,byPage")]
 		/**
 		 * Determines how the slider's value changes when the track is touched.
 		 *
@@ -904,6 +914,7 @@ package feathers.controls
 		 * @default Slider.TRACK_INTERACTION_MODE_TO_VALUE
 		 *
 		 * @see #TRACK_INTERACTION_MODE_TO_VALUE
+		 * @see #TRACK_INTERACTION_MODE_TO_VALUE_WITH_DRAG
 		 * @see #TRACK_INTERACTION_MODE_BY_PAGE
 		 * @see #page
 		 */
@@ -2113,7 +2124,8 @@ package feathers.controls
 				{
 					return;
 				}
-				if(!this._showThumb && touch.phase == TouchPhase.MOVED)
+				if(touch.phase === TouchPhase.MOVED &&
+					(!this._showThumb || this._trackInteractionMode === TRACK_INTERACTION_MODE_TO_VALUE_WITH_DRAG))
 				{
 					touch.getLocation(this, HELPER_POINT);
 					this.value = this.locationToValue(HELPER_POINT);


### PR DESCRIPTION
Backported the new TRACK_INTERACTION_MODE_TO_VALUE_WITH_DRAG constant (issue #1220) from master to 2.3.x branch. This is a useful track interaction mode, which would be nice to immediately be able to use in the stable branch.