### PR TITLE
fix screen reloading in infinite loop

### DIFF
--- a/source/feathers/controls/supportClasses/BaseScreenNavigator.as
+++ b/source/feathers/controls/supportClasses/BaseScreenNavigator.as
@@ -956,7 +956,9 @@ package feathers.controls.supportClasses
 			}
 			else if(this._nextScreenID !== null)
 			{
-				this.showScreenInternal(this._nextScreenID, this._nextScreenTransition);
+				var next:String = this._nextScreenID;
+				this._nextScreenID = null;
+				this.showScreenInternal(next, this._nextScreenTransition);
 			}
 
 			this._nextScreenID = null;


### PR DESCRIPTION
fix issue where BaseScreenNavigator could get caught in infinite loop after calling 'popToRootScreenAndReplace()' on StackScreenNavigator, due to `_nextScreenID` not getting cleared.

problem case:
1. We call `popToRootScreenAndReplace("NewRootScreenID", null);`
2. When the new root screen is initializing, it detects that a certain flag is true and triggers an event that immediately pushes a new screen to the stack. For example, if the root screen is a login screen, but the login screen detects a cookie and immediately continues to the next screen.
3. The newest screen loads repeatedly in an infinite loop because `_nextScreenID` never gets cleared and `transitionComplete` always calls `showScreenInternal()` again.