### PR TITLE
LinearLayout base class

### DIFF
--- a/source/feathers/layout/HorizontalLayout.as
+++ b/source/feathers/layout/HorizontalLayout.as
@@ -10,9 +10,7 @@ package feathers.layout
 	import flash.errors.IllegalOperationError;
 	import flash.geom.Point;
 	import flash.ui.Keyboard;
-	
-	import mx.effects.easing.Linear;
-	
+		
 	import feathers.core.IFeathersControl;
 	import feathers.core.IMeasureDisplayObject;
 	import feathers.core.IValidating;

--- a/source/feathers/layout/HorizontalLayout.as
+++ b/source/feathers/layout/HorizontalLayout.as
@@ -7,68 +7,19 @@ accordance with the terms of the accompanying license agreement.
 */
 package feathers.layout
 {
-	import feathers.core.IFeathersControl;
-	import feathers.core.IMeasureDisplayObject;
-	import feathers.core.IValidating;
-
 	import flash.errors.IllegalOperationError;
 	import flash.geom.Point;
 	import flash.ui.Keyboard;
-
+	
+	import mx.effects.easing.Linear;
+	
+	import feathers.core.IFeathersControl;
+	import feathers.core.IMeasureDisplayObject;
+	import feathers.core.IValidating;
+	
 	import starling.display.DisplayObject;
 	import starling.events.Event;
 	import starling.events.EventDispatcher;
-
-	/**
-	 * Dispatched when a property of the layout changes, indicating that a
-	 * redraw is probably needed.
-	 *
-	 * <p>The properties of the event object have the following values:</p>
-	 * <table class="innertable">
-	 * <tr><th>Property</th><th>Value</th></tr>
-	 * <tr><td><code>bubbles</code></td><td>false</td></tr>
-	 * <tr><td><code>currentTarget</code></td><td>The Object that defines the
-	 *   event listener that handles the event. For example, if you use
-	 *   <code>myButton.addEventListener()</code> to register an event listener,
-	 *   myButton is the value of the <code>currentTarget</code>.</td></tr>
-	 * <tr><td><code>data</code></td><td>null</td></tr>
-	 * <tr><td><code>target</code></td><td>The Object that dispatched the event;
-	 *   it is not always the Object listening for the event. Use the
-	 *   <code>currentTarget</code> property to always access the Object
-	 *   listening for the event.</td></tr>
-	 * </table>
-	 *
-	 * @eventType starling.events.Event.CHANGE
-	 */
-	[Event(name="change",type="starling.events.Event")]
-
-	/**
-	 * Dispatched when the layout would like to adjust the container's scroll
-	 * position. Typically, this is used when the virtual dimensions of an item
-	 * differ from its real dimensions. This event allows the container to
-	 * adjust scrolling so that it appears smooth, without jarring jumps or
-	 * shifts when an item resizes.
-	 *
-	 * <p>The properties of the event object have the following values:</p>
-	 * <table class="innertable">
-	 * <tr><th>Property</th><th>Value</th></tr>
-	 * <tr><td><code>bubbles</code></td><td>false</td></tr>
-	 * <tr><td><code>currentTarget</code></td><td>The Object that defines the
-	 *   event listener that handles the event. For example, if you use
-	 *   <code>myButton.addEventListener()</code> to register an event listener,
-	 *   myButton is the value of the <code>currentTarget</code>.</td></tr>
-	 * <tr><td><code>data</code></td><td>A <code>flash.geom.Point</code> object
-	 *   representing how much the scroll position should be adjusted in both
-	 *   horizontal and vertical directions. Measured in pixels.</td></tr>
-	 * <tr><td><code>target</code></td><td>The Object that dispatched the event;
-	 *   it is not always the Object listening for the event. Use the
-	 *   <code>currentTarget</code> property to always access the Object
-	 *   listening for the event.</td></tr>
-	 * </table>
-	 *
-	 * @eventType starling.events.Event.SCROLL
-	 */
-	[Event(name="scroll",type="starling.events.Event")]
 
 	/**
 	 * Positions items from left to right in a single row.
@@ -77,7 +28,7 @@ package feathers.layout
 	 *
 	 * @productversion Feathers 1.0.0
 	 */
-	public class HorizontalLayout extends EventDispatcher implements IVariableVirtualLayout, ITrimmedVirtualLayout
+	public class HorizontalLayout extends LinearLayout implements IVariableVirtualLayout, ITrimmedVirtualLayout
 	{
 		[Deprecated(replacement="feathers.layout.VerticalAlign.TOP",since="3.0.0")]
 		/**
@@ -174,459 +125,6 @@ package feathers.layout
 		/**
 		 * @private
 		 */
-		protected var _widthCache:Array = [];
-
-		/**
-		 * @private
-		 */
-		protected var _discoveredItemsCache:Vector.<DisplayObject> = new <DisplayObject>[];
-
-		/**
-		 * @private
-		 */
-		protected var _gap:Number = 0;
-
-		/**
-		 * The space, in pixels, between items.
-		 *
-		 * @default 0
-		 */
-		public function get gap():Number
-		{
-			return this._gap;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set gap(value:Number):void
-		{
-			if(this._gap == value)
-			{
-				return;
-			}
-			this._gap = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _firstGap:Number = NaN;
-
-		/**
-		 * The space, in pixels, between the first and second items. If the
-		 * value of <code>firstGap</code> is <code>NaN</code>, the value of the
-		 * <code>gap</code> property will be used instead.
-		 *
-		 * @default NaN
-		 */
-		public function get firstGap():Number
-		{
-			return this._firstGap;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set firstGap(value:Number):void
-		{
-			if(this._firstGap == value)
-			{
-				return;
-			}
-			this._firstGap = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _lastGap:Number = NaN;
-
-		/**
-		 * The space, in pixels, between the last and second to last items. If
-		 * the value of <code>lastGap</code> is <code>NaN</code>, the value of
-		 * the <code>gap</code> property will be used instead.
-		 *
-		 * @default NaN
-		 */
-		public function get lastGap():Number
-		{
-			return this._lastGap;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set lastGap(value:Number):void
-		{
-			if(this._lastGap == value)
-			{
-				return;
-			}
-			this._lastGap = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * Quickly sets all padding properties to the same value. The
-		 * <code>padding</code> getter always returns the value of
-		 * <code>paddingTop</code>, but the other padding values may be
-		 * different.
-		 *
-		 * @default 0
-		 *
-		 * @see #paddingTop
-		 * @see #paddingRight
-		 * @see #paddingBottom
-		 * @see #paddingLeft
-		 */
-		public function get padding():Number
-		{
-			return this._paddingTop;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set padding(value:Number):void
-		{
-			this.paddingTop = value;
-			this.paddingRight = value;
-			this.paddingBottom = value;
-			this.paddingLeft = value;
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _paddingTop:Number = 0;
-
-		/**
-		 * The minimum space, in pixels, above the items.
-		 *
-		 * @default 0
-		 */
-		public function get paddingTop():Number
-		{
-			return this._paddingTop;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set paddingTop(value:Number):void
-		{
-			if(this._paddingTop == value)
-			{
-				return;
-			}
-			this._paddingTop = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _paddingRight:Number = 0;
-
-		/**
-		 * The space, in pixels, that appears to the right, after the last item.
-		 *
-		 * @default 0
-		 */
-		public function get paddingRight():Number
-		{
-			return this._paddingRight;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set paddingRight(value:Number):void
-		{
-			if(this._paddingRight == value)
-			{
-				return;
-			}
-			this._paddingRight = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _paddingBottom:Number = 0;
-
-		/**
-		 * The minimum space, in pixels, above the items.
-		 *
-		 * @default 0
-		 */
-		public function get paddingBottom():Number
-		{
-			return this._paddingBottom;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set paddingBottom(value:Number):void
-		{
-			if(this._paddingBottom == value)
-			{
-				return;
-			}
-			this._paddingBottom = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _paddingLeft:Number = 0;
-
-		/**
-		 * The space, in pixels, that appears to the left, before the first
-		 * item.
-		 *
-		 * @default 0
-		 */
-		public function get paddingLeft():Number
-		{
-			return this._paddingLeft;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set paddingLeft(value:Number):void
-		{
-			if(this._paddingLeft == value)
-			{
-				return;
-			}
-			this._paddingLeft = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-
-		/**
-		 * @private
-		 */
-		protected var _verticalAlign:String = VerticalAlign.TOP;
-
-		[Inspectable(type="String",enumeration="top,middle,bottom,justify")]
-		/**
-		 * The alignment of the items vertically, on the y-axis.
-		 *
-		 * <p>If the <code>verticalAlign</code> property is set to
-		 * <code>VerticalAlign.JUSTIFY</code>, the
-		 * <code>height</code>, <code>minHeight</code>, and
-		 * <code>maxHeight</code> properties of the items may be changed, and
-		 * their original values ignored by the layout. In this situation, if
-		 * the height needs to be constrained, the <code>height</code>,
-		 * <code>minHeight</code>, or <code>maxHeight</code> properties should
-		 * instead be set on the parent container that is using this layout.</p>
-		 *
-		 * @default feathers.layout.VerticalAlign.TOP
-		 *
-		 * @see feathers.layout.VerticalAlign#TOP
-		 * @see feathers.layout.VerticalAlign#MIDDLE
-		 * @see feathers.layout.VerticalAlign#BOTTOM
-		 * @see feathers.layout.VerticalAlign#JUSTIFY
-		 */
-		public function get verticalAlign():String
-		{
-			return this._verticalAlign;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set verticalAlign(value:String):void
-		{
-			if(this._verticalAlign == value)
-			{
-				return;
-			}
-			this._verticalAlign = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _horizontalAlign:String = HorizontalAlign.LEFT;
-
-		[Inspectable(type="String",enumeration="left,center,right")]
-		/**
-		 * If the total item width is less than the bounds, the positions of
-		 * the items can be aligned horizontally.
-		 *
-		 * @default feathers.layout.HorizontalAlign.LEFT
-		 *
-		 * @see feathers.layout.HorizontalAlign#LEFT
-		 * @see feathers.layout.HorizontalAlign#CENTER
-		 * @see feathers.layout.HorizontalAlign#RIGHT
-		 */
-		public function get horizontalAlign():String
-		{
-			return this._horizontalAlign;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set horizontalAlign(value:String):void
-		{
-			if(this._horizontalAlign == value)
-			{
-				return;
-			}
-			this._horizontalAlign = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _useVirtualLayout:Boolean = true;
-
-		/**
-		 * @inheritDoc
-		 *
-		 * @default true
-		 */
-		public function get useVirtualLayout():Boolean
-		{
-			return this._useVirtualLayout;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set useVirtualLayout(value:Boolean):void
-		{
-			if(this._useVirtualLayout == value)
-			{
-				return;
-			}
-			this._useVirtualLayout = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _hasVariableItemDimensions:Boolean = false;
-
-		/**
-		 * When the layout is virtualized, and this value is true, the items may
-		 * have variable width values. If false, the items will all share the
-		 * same width value with the typical item.
-		 *
-		 * @default false
-		 */
-		public function get hasVariableItemDimensions():Boolean
-		{
-			return this._hasVariableItemDimensions;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set hasVariableItemDimensions(value:Boolean):void
-		{
-			if(this._hasVariableItemDimensions == value)
-			{
-				return;
-			}
-			this._hasVariableItemDimensions = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _requestedColumnCount:int = 0;
-
-		/**
-		 * Requests that the layout set the view port dimensions to display a
-		 * specific number of columns (plus gaps and padding), if possible. If
-		 * the explicit width of the view port is set, then this value will be
-		 * ignored. If the view port's minimum and/or maximum width are set,
-		 * the actual number of visible columns may be adjusted to meet those
-		 * requirements. Set this value to <code>0</code> to display as many
-		 * columns as possible.
-		 *
-		 * @default 0
-		 * 
-		 * @see #maxColumnCount
-		 */
-		public function get requestedColumnCount():int
-		{
-			return this._requestedColumnCount;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set requestedColumnCount(value:int):void
-		{
-			if(value < 0)
-			{
-				throw RangeError("requestedColumnCount requires a value >= 0");
-			}
-			if(this._requestedColumnCount == value)
-			{
-				return;
-			}
-			this._requestedColumnCount = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _maxColumnCount:int = 0;
-
-		/**
-		 * The maximum number of columns to display. If the explicit width of
-		 * the view port is set or if the <code>requestedColumnCount</code> is
-		 * set, then this value will be ignored. If the view port's minimum
-		 * and/or maximum width are set, the actual number of visible columns
-		 * may be adjusted to meet those requirements. Set this value to
-		 * <code>0</code> to display as many columns as possible.
-		 *
-		 * @default 0
-		 */
-		public function get maxColumnCount():int
-		{
-			return this._maxColumnCount;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set maxColumnCount(value:int):void
-		{
-			if(value < 0)
-			{
-				throw RangeError("maxColumnCount requires a value >= 0");
-			}
-			if(this._maxColumnCount === value)
-			{
-				return;
-			}
-			this._maxColumnCount = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
 		protected var _distributeWidths:Boolean = false;
 
 		/**
@@ -654,218 +152,81 @@ package feathers.layout
 			this._distributeWidths = value;
 			this.dispatchEventWith(Event.CHANGE);
 		}
-
+		
 		/**
 		 * @private
 		 */
-		protected var _beforeVirtualizedItemCount:int = 0;
-
+		protected var _requestedColumnCount:int = 0;
+		
 		/**
-		 * @inheritDoc
+		 * Requests that the layout set the view port dimensions to display a
+		 * specific number of columns (plus gaps and padding), if possible. If
+		 * the explicit width of the view port is set, then this value will be
+		 * ignored. If the view port's minimum and/or maximum width are set,
+		 * the actual number of visible columns may be adjusted to meet those
+		 * requirements. Set this value to <code>0</code> to display as many
+		 * columns as possible.
+		 *
+		 * @default 0
+		 * 
+		 * @see #maxColumnCount
 		 */
-		public function get beforeVirtualizedItemCount():int
+		public function get requestedColumnCount():int
 		{
-			return this._beforeVirtualizedItemCount;
+			return this._requestedColumnCount;
 		}
-
+		
 		/**
 		 * @private
 		 */
-		public function set beforeVirtualizedItemCount(value:int):void
+		public function set requestedColumnCount(value:int):void
 		{
-			if(this._beforeVirtualizedItemCount == value)
+			if(value < 0)
+			{
+				throw RangeError("requestedColumnCount requires a value >= 0");
+			}
+			if(this._requestedColumnCount == value)
 			{
 				return;
 			}
-			this._beforeVirtualizedItemCount = value;
+			this._requestedColumnCount = value;
 			this.dispatchEventWith(Event.CHANGE);
 		}
-
+		
 		/**
 		 * @private
 		 */
-		protected var _afterVirtualizedItemCount:int = 0;
-
+		protected var _maxColumnCount:int = 0;
+		
 		/**
-		 * @inheritDoc
+		 * The maximum number of columns to display. If the explicit width of
+		 * the view port is set or if the <code>requestedColumnCount</code> is
+		 * set, then this value will be ignored. If the view port's minimum
+		 * and/or maximum width are set, the actual number of visible columns
+		 * may be adjusted to meet those requirements. Set this value to
+		 * <code>0</code> to display as many columns as possible.
+		 *
+		 * @default 0
 		 */
-		public function get afterVirtualizedItemCount():int
+		public function get maxColumnCount():int
 		{
-			return this._afterVirtualizedItemCount;
+			return this._maxColumnCount;
 		}
-
+		
 		/**
 		 * @private
 		 */
-		public function set afterVirtualizedItemCount(value:int):void
+		public function set maxColumnCount(value:int):void
 		{
-			if(this._afterVirtualizedItemCount == value)
+			if(value < 0)
+			{
+				throw RangeError("maxColumnCount requires a value >= 0");
+			}
+			if(this._maxColumnCount === value)
 			{
 				return;
 			}
-			this._afterVirtualizedItemCount = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _typicalItem:DisplayObject;
-
-		/**
-		 * @inheritDoc
-		 *
-		 * @see #resetTypicalItemDimensionsOnMeasure
-		 * @see #typicalItemWidth
-		 * @see #typicalItemHeight
-		 */
-		public function get typicalItem():DisplayObject
-		{
-			return this._typicalItem;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set typicalItem(value:DisplayObject):void
-		{
-			if(this._typicalItem == value)
-			{
-				return;
-			}
-			this._typicalItem = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _resetTypicalItemDimensionsOnMeasure:Boolean = false;
-
-		/**
-		 * If set to <code>true</code>, the width and height of the
-		 * <code>typicalItem</code> will be reset to <code>typicalItemWidth</code>
-		 * and <code>typicalItemHeight</code>, respectively, whenever the
-		 * typical item needs to be measured. The measured dimensions of the
-		 * typical item are used to fill in the blanks of a virtualized layout
-		 * for virtual items that don't have their own display objects to
-		 * measure yet.
-		 *
-		 * @default false
-		 *
-		 * @see #typicalItemWidth
-		 * @see #typicalItemHeight
-		 * @see #typicalItem
-		 */
-		public function get resetTypicalItemDimensionsOnMeasure():Boolean
-		{
-			return this._resetTypicalItemDimensionsOnMeasure;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set resetTypicalItemDimensionsOnMeasure(value:Boolean):void
-		{
-			if(this._resetTypicalItemDimensionsOnMeasure == value)
-			{
-				return;
-			}
-			this._resetTypicalItemDimensionsOnMeasure = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _typicalItemWidth:Number = NaN;
-
-		/**
-		 * Used to reset the width, in pixels, of the <code>typicalItem</code>
-		 * for measurement. The measured dimensions of the typical item are used
-		 * to fill in the blanks of a virtualized layout for virtual items that
-		 * don't have their own display objects to measure yet.
-		 *
-		 * <p>This value is only used when <code>resetTypicalItemDimensionsOnMeasure</code>
-		 * is set to <code>true</code>. If <code>resetTypicalItemDimensionsOnMeasure</code>
-		 * is set to <code>false</code>, this value will be ignored and the
-		 * <code>typicalItem</code> dimensions will not be reset before
-		 * measurement.</p>
-		 *
-		 * <p>If <code>typicalItemWidth</code> is set to <code>NaN</code>, the
-		 * typical item will auto-size itself to its preferred width. If you
-		 * pass a valid <code>Number</code> value, the typical item's width will
-		 * be set to a fixed size. May be used in combination with
-		 * <code>typicalItemHeight</code>.</p>
-		 *
-		 * @default NaN
-		 *
-		 * @see #resetTypicalItemDimensionsOnMeasure
-		 * @see #typicalItemHeight
-		 * @see #typicalItem
-		 */
-		public function get typicalItemWidth():Number
-		{
-			return this._typicalItemWidth;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set typicalItemWidth(value:Number):void
-		{
-			if(this._typicalItemWidth == value)
-			{
-				return;
-			}
-			this._typicalItemWidth = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _typicalItemHeight:Number = NaN;
-
-		/**
-		 * Used to reset the height, in pixels, of the <code>typicalItem</code>
-		 * for measurement. The measured dimensions of the typical item are used
-		 * to fill in the blanks of a virtualized layout for virtual items that
-		 * don't have their own display objects to measure yet.
-		 *
-		 * <p>This value is only used when <code>resetTypicalItemDimensionsOnMeasure</code>
-		 * is set to <code>true</code>. If <code>resetTypicalItemDimensionsOnMeasure</code>
-		 * is set to <code>false</code>, this value will be ignored and the
-		 * <code>typicalItem</code> dimensions will not be reset before
-		 * measurement.</p>
-		 *
-		 * <p>If <code>typicalItemHeight</code> is set to <code>NaN</code>, the
-		 * typical item will auto-size itself to its preferred height. If you
-		 * pass a valid <code>Number</code> value, the typical item's height will
-		 * be set to a fixed size. May be used in combination with
-		 * <code>typicalItemWidth</code>.</p>
-		 *
-		 * @default NaN
-		 *
-		 * @see #resetTypicalItemDimensionsOnMeasure
-		 * @see #typicalItemWidth
-		 * @see #typicalItem
-		 */
-		public function get typicalItemHeight():Number
-		{
-			return this._typicalItemHeight;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set typicalItemHeight(value:Number):void
-		{
-			if(this._typicalItemHeight == value)
-			{
-				return;
-			}
-			this._typicalItemHeight = value;
+			this._maxColumnCount = value;
 			this.dispatchEventWith(Event.CHANGE);
 		}
 
@@ -901,7 +262,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function get requiresLayoutOnScroll():Boolean
+		public override function get requiresLayoutOnScroll():Boolean
 		{
 			return this._useVirtualLayout;
 		}
@@ -909,7 +270,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function layout(items:Vector.<DisplayObject>, viewPortBounds:ViewPortBounds = null, result:LayoutBoundsResult = null):LayoutBoundsResult
+		public override function layout(items:Vector.<DisplayObject>, viewPortBounds:ViewPortBounds = null, result:LayoutBoundsResult = null):LayoutBoundsResult
 		{
 			//this function is very long because it may be called every frame,
 			//in some situations. testing revealed that splitting this function
@@ -1046,7 +407,7 @@ package feathers.layout
 
 				if(this._useVirtualLayout && this._hasVariableItemDimensions)
 				{
-					var cachedWidth:Number = this._widthCache[iNormalized];
+					var cachedWidth:Number = this._cache[iNormalized];
 				}
 				if(this._useVirtualLayout && !item)
 				{
@@ -1102,7 +463,7 @@ package feathers.layout
 								//the container that the virtualized layout has
 								//changed, and it the view port may need to be
 								//re-measured.
-								this._widthCache[iNormalized] = itemWidth;
+								this._cache[iNormalized] = itemWidth;
 
 								//attempt to adjust the scroll position so that
 								//it looks like we're scrolling smoothly after
@@ -1381,7 +742,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function measureViewPort(itemCount:int, viewPortBounds:ViewPortBounds = null, result:Point = null):Point
+		public override function measureViewPort(itemCount:int, viewPortBounds:ViewPortBounds = null, result:Point = null):Point
 		{
 			if(!result)
 			{
@@ -1430,7 +791,7 @@ package feathers.layout
 				{
 					for(var i:int = 0; i < itemCount; i++)
 					{
-						var cachedWidth:Number = this._widthCache[i];
+						var cachedWidth:Number = this._cache[i];
 						if(cachedWidth !== cachedWidth) //isNaN
 						{
 							positionX += calculatedTypicalItemWidth + this._gap;
@@ -1509,45 +870,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function resetVariableVirtualCache():void
-		{
-			this._widthCache.length = 0;
-		}
-
-		/**
-		 * @inheritDoc
-		 */
-		public function resetVariableVirtualCacheAtIndex(index:int, item:DisplayObject = null):void
-		{
-			delete this._widthCache[index];
-			if(item)
-			{
-				this._widthCache[index] = item.width;
-				this.dispatchEventWith(Event.CHANGE);
-			}
-		}
-
-		/**
-		 * @inheritDoc
-		 */
-		public function addToVariableVirtualCacheAtIndex(index:int, item:DisplayObject = null):void
-		{
-			var widthValue:* = item ? item.width : undefined;
-			this._widthCache.insertAt(index, widthValue);
-		}
-
-		/**
-		 * @inheritDoc
-		 */
-		public function removeFromVariableVirtualCacheAtIndex(index:int):void
-		{
-			this._widthCache.removeAt(index);
-		}
-
-		/**
-		 * @inheritDoc
-		 */
-		public function getVisibleIndicesAtScrollPosition(scrollX:Number, scrollY:Number, width:Number, height:Number, itemCount:int, result:Vector.<int> = null):Vector.<int>
+		public override function getVisibleIndicesAtScrollPosition(scrollX:Number, scrollY:Number, width:Number, height:Number, itemCount:int, result:Vector.<int> = null):Vector.<int>
 		{
 			if(result)
 			{
@@ -1648,7 +971,7 @@ package feathers.layout
 				{
 					gap = this._lastGap;
 				}
-				var cachedWidth:Number = this._widthCache[i];
+				var cachedWidth:Number = this._cache[i];
 				if(cachedWidth !== cachedWidth) //isNaN
 				{
 					var itemWidth:Number = calculatedTypicalItemWidth;
@@ -1714,7 +1037,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function getNearestScrollPositionForIndex(index:int, scrollX:Number, scrollY:Number, items:Vector.<DisplayObject>,
+		public override function getNearestScrollPositionForIndex(index:int, scrollX:Number, scrollY:Number, items:Vector.<DisplayObject>,
 			x:Number, y:Number, width:Number, height:Number, result:Point = null):Point
 		{
 			var maxScrollX:Number = this.calculateMaxScrollXOfIndex(index, items, x, y, width, height);
@@ -1723,7 +1046,7 @@ package feathers.layout
 			{
 				if(this._hasVariableItemDimensions)
 				{
-					var itemWidth:Number = this._widthCache[index];
+					var itemWidth:Number = this._cache[index];
 					if(itemWidth !== itemWidth)
 					{
 						itemWidth = this._typicalItem.width;
@@ -1772,7 +1095,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function calculateNavigationDestination(items:Vector.<DisplayObject>, index:int, keyCode:uint, bounds:LayoutBoundsResult):int
+		public override function calculateNavigationDestination(items:Vector.<DisplayObject>, index:int, keyCode:uint, bounds:LayoutBoundsResult):int
 		{
 			var itemArrayCount:int = items.length;
 			var itemCount:int = itemArrayCount + this._beforeVirtualizedItemCount + this._afterVirtualizedItemCount;
@@ -1809,7 +1132,7 @@ package feathers.layout
 					var iNormalized:int = i + indexOffset;
 					if(this._useVirtualLayout && this._hasVariableItemDimensions)
 					{
-						var cachedWidth:Number = this._widthCache[i];
+						var cachedWidth:Number = this._cache[i];
 					}
 					if(iNormalized < 0 || iNormalized >= itemArrayCount)
 					{
@@ -1862,7 +1185,7 @@ package feathers.layout
 					iNormalized = i + indexOffset;
 					if(this._useVirtualLayout && this._hasVariableItemDimensions)
 					{
-						cachedWidth = this._widthCache[i];
+						cachedWidth = this._cache[i];
 					}
 					if(iNormalized < 0 || iNormalized >= itemArrayCount)
 					{
@@ -1924,14 +1247,14 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function getScrollPositionForIndex(index:int, items:Vector.<DisplayObject>, x:Number, y:Number, width:Number, height:Number, result:Point = null):Point
+		public override function getScrollPositionForIndex(index:int, items:Vector.<DisplayObject>, x:Number, y:Number, width:Number, height:Number, result:Point = null):Point
 		{
 			var maxScrollX:Number = this.calculateMaxScrollXOfIndex(index, items, x, y, width, height);
 			if(this._useVirtualLayout)
 			{
 				if(this._hasVariableItemDimensions)
 				{
-					var itemWidth:Number = this._widthCache[index];
+					var itemWidth:Number = this._cache[index];
 					if(itemWidth !== itemWidth)
 					{
 						itemWidth = this._typicalItem.width;
@@ -2403,7 +1726,7 @@ package feathers.layout
 				}
 				if(this._useVirtualLayout && this._hasVariableItemDimensions)
 				{
-					var cachedWidth:Number = this._widthCache[iNormalized];
+					var cachedWidth:Number = this._cache[iNormalized];
 				}
 				if(this._useVirtualLayout && !item)
 				{
@@ -2426,7 +1749,7 @@ package feathers.layout
 						{
 							if(itemWidth != cachedWidth)
 							{
-								this._widthCache[iNormalized] = itemWidth;
+								this._cache[iNormalized] = itemWidth;
 								this.dispatchEventWith(Event.CHANGE);
 							}
 						}

--- a/source/feathers/layout/LinearLayout.as
+++ b/source/feathers/layout/LinearLayout.as
@@ -1,0 +1,782 @@
+/*
+Feathers
+Copyright 2012-2017 Bowler Hat LLC. All Rights Reserved.
+
+This program is free software. You can redistribute and/or modify it in
+accordance with the terms of the accompanying license agreement.
+*/
+package feathers.layout
+{
+	import feathers.core.IFeathersControl;
+	import feathers.core.IMeasureDisplayObject;
+	import feathers.core.IValidating;
+
+	import flash.errors.IllegalOperationError;
+	import flash.geom.Point;
+	import flash.ui.Keyboard;
+
+	import starling.display.DisplayObject;
+
+	import starling.display.DisplayObject;
+	import starling.display.DisplayObjectContainer;
+	import starling.errors.AbstractMethodError;
+	import starling.events.Event;
+	import starling.events.EventDispatcher;
+	import starling.utils.Pool;
+
+	/**
+	 * Dispatched when a property of the layout changes, indicating that a
+	 * redraw is probably needed.
+	 *
+	 * <p>The properties of the event object have the following values:</p>
+	 * <table class="innertable">
+	 * <tr><th>Property</th><th>Value</th></tr>
+	 * <tr><td><code>bubbles</code></td><td>false</td></tr>
+	 * <tr><td><code>currentTarget</code></td><td>The Object that defines the
+	 *   event listener that handles the event. For example, if you use
+	 *   <code>myButton.addEventListener()</code> to register an event listener,
+	 *   myButton is the value of the <code>currentTarget</code>.</td></tr>
+	 * <tr><td><code>data</code></td><td>null</td></tr>
+	 * <tr><td><code>target</code></td><td>The Object that dispatched the event;
+	 *   it is not always the Object listening for the event. Use the
+	 *   <code>currentTarget</code> property to always access the Object
+	 *   listening for the event.</td></tr>
+	 * </table>
+	 *
+	 * @eventType starling.events.Event.CHANGE
+	 */
+	[Event(name="change",type="starling.events.Event")]
+
+	/**
+	 * Dispatched when the layout would like to adjust the container's scroll
+	 * position. Typically, this is used when the virtual dimensions of an item
+	 * differ from its real dimensions. This event allows the container to
+	 * adjust scrolling so that it appears smooth, without jarring jumps or
+	 * shifts when an item resizes.
+	 *
+	 * <p>The properties of the event object have the following values:</p>
+	 * <table class="innertable">
+	 * <tr><th>Property</th><th>Value</th></tr>
+	 * <tr><td><code>bubbles</code></td><td>false</td></tr>
+	 * <tr><td><code>currentTarget</code></td><td>The Object that defines the
+	 *   event listener that handles the event. For example, if you use
+	 *   <code>myButton.addEventListener()</code> to register an event listener,
+	 *   myButton is the value of the <code>currentTarget</code>.</td></tr>
+	 * <tr><td><code>data</code></td><td>A <code>flash.geom.Point</code> object
+	 *   representing how much the scroll position should be adjusted in both
+	 *   horizontal and vertical directions. Measured in pixels.</td></tr>
+	 * <tr><td><code>target</code></td><td>The Object that dispatched the event;
+	 *   it is not always the Object listening for the event. Use the
+	 *   <code>currentTarget</code> property to always access the Object
+	 *   listening for the event.</td></tr>
+	 * </table>
+	 *
+	 * @eventType starling.events.Event.SCROLL
+	 */
+	[Event(name="scroll",type="starling.events.Event")]
+
+	/**
+	 * Positions items from top to bottom in a single column.
+	 *
+	 * @see ../../../help/vertical-layout.html How to use VerticalLayout with Feathers containers
+	 *
+	 * @productversion Feathers 1.0.0
+	 */
+	public class LinearLayout extends EventDispatcher implements IVariableVirtualLayout, ITrimmedVirtualLayout
+	{
+		/**
+		 * Constructor.
+		 */
+		public function LinearLayout()
+		{
+			super();
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _cache:Array = [];
+
+		/**
+		 * @private
+		 */
+		protected var _discoveredItemsCache:Vector.<DisplayObject> = new <DisplayObject>[];
+
+		/**
+		 * @private
+		 */
+		protected var _gap:Number = 0;
+
+		/**
+		 * The space, in pixels, between items.
+		 *
+		 * @default 0
+		 */
+		public function get gap():Number
+		{
+			return this._gap;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set gap(value:Number):void
+		{
+			if(this._gap == value)
+			{
+				return;
+			}
+			this._gap = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _firstGap:Number = NaN;
+
+		/**
+		 * The space, in pixels, between the first and second items. If the
+		 * value of <code>firstGap</code> is <code>NaN</code>, the value of the
+		 * <code>gap</code> property will be used instead.
+		 *
+		 * @default NaN
+		 */
+		public function get firstGap():Number
+		{
+			return this._firstGap;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set firstGap(value:Number):void
+		{
+			if(this._firstGap == value)
+			{
+				return;
+			}
+			this._firstGap = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _lastGap:Number = NaN;
+
+		/**
+		 * The space, in pixels, between the last and second to last items. If
+		 * the value of <code>lastGap</code> is <code>NaN</code>, the value of
+		 * the <code>gap</code> property will be used instead.
+		 *
+		 * @default NaN
+		 */
+		public function get lastGap():Number
+		{
+			return this._lastGap;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set lastGap(value:Number):void
+		{
+			if(this._lastGap == value)
+			{
+				return;
+			}
+			this._lastGap = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * Quickly sets all padding properties to the same value. The
+		 * <code>padding</code> getter always returns the value of
+		 * <code>paddingTop</code>, but the other padding values may be
+		 * different.
+		 *
+		 * @default 0
+		 *
+		 * @see #paddingTop
+		 * @see #paddingRight
+		 * @see #paddingBottom
+		 * @see #paddingLeft
+		 */
+		public function get padding():Number
+		{
+			return this._paddingTop;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set padding(value:Number):void
+		{
+			this.paddingTop = value;
+			this.paddingRight = value;
+			this.paddingBottom = value;
+			this.paddingLeft = value;
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _paddingTop:Number = 0;
+
+		/**
+		 * The space, in pixels, that appears on top, before the first item.
+		 *
+		 * @default 0
+		 */
+		public function get paddingTop():Number
+		{
+			return this._paddingTop;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set paddingTop(value:Number):void
+		{
+			if(this._paddingTop == value)
+			{
+				return;
+			}
+			this._paddingTop = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _paddingRight:Number = 0;
+
+		/**
+		 * The minimum space, in pixels, to the right of the items.
+		 *
+		 * @default 0
+		 */
+		public function get paddingRight():Number
+		{
+			return this._paddingRight;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set paddingRight(value:Number):void
+		{
+			if(this._paddingRight == value)
+			{
+				return;
+			}
+			this._paddingRight = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _paddingBottom:Number = 0;
+
+		/**
+		 * The space, in pixels, that appears on the bottom, after the last
+		 * item.
+		 *
+		 * @default 0
+		 */
+		public function get paddingBottom():Number
+		{
+			return this._paddingBottom;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set paddingBottom(value:Number):void
+		{
+			if(this._paddingBottom == value)
+			{
+				return;
+			}
+			this._paddingBottom = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _paddingLeft:Number = 0;
+
+		/**
+		 * The minimum space, in pixels, to the left of the items.
+		 *
+		 * @default 0
+		 */
+		public function get paddingLeft():Number
+		{
+			return this._paddingLeft;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set paddingLeft(value:Number):void
+		{
+			if(this._paddingLeft == value)
+			{
+				return;
+			}
+			this._paddingLeft = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+
+		/**
+		 * @private
+		 */
+		protected var _verticalAlign:String = VerticalAlign.TOP;
+
+		[Inspectable(type="String",enumeration="top,middle,bottom")]
+		/**
+		 * If the total item height is less than the bounds, the positions of
+		 * the items can be aligned vertically.
+		 *
+		 * @default feathers.layout.VerticalAlign.TOP
+		 *
+		 * @see feathers.layout.VerticalAlign#TOP
+		 * @see feathers.layout.VerticalAlign#MIDDLE
+		 * @see feathers.layout.VerticalAlign#BOTTOM
+		 */
+		public function get verticalAlign():String
+		{
+			return this._verticalAlign;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set verticalAlign(value:String):void
+		{
+			if(this._verticalAlign == value)
+			{
+				return;
+			}
+			this._verticalAlign = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _horizontalAlign:String = HorizontalAlign.LEFT;
+
+		[Inspectable(type="String",enumeration="left,center,right,justify")]
+		/**
+		 * The alignment of the items horizontally, on the x-axis.
+		 *
+		 * <p>If the <code>horizontalAlign</code> property is set to
+		 * <code>VerticalLayout.HorizontalAlign.JUSTIFY</code>, the
+		 * <code>width</code>, <code>minWidth</code>, and <code>maxWidth</code>
+		 * properties of the items may be changed, and their original values
+		 * ignored by the layout. In this situation, if the width needs to be
+		 * constrained, the <code>width</code>, <code>minWidth</code>, or
+		 * <code>maxWidth</code> properties should instead be set on the parent
+		 * container using the layout.</p>
+		 *
+		 * @default feathers.layout.HorizontalAlign.LEFT
+		 *
+		 * @see feathers.layout.HorizontalAlign#LEFT
+		 * @see feathers.layout.HorizontalAlign#CENTER
+		 * @see feathers.layout.HorizontalAlign#RIGHT
+		 * @see feathers.layout.HorizontalAlign#JUSTIFY
+		 */
+		public function get horizontalAlign():String
+		{
+			return this._horizontalAlign;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set horizontalAlign(value:String):void
+		{
+			if(this._horizontalAlign == value)
+			{
+				return;
+			}
+			this._horizontalAlign = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _useVirtualLayout:Boolean = true;
+
+		/**
+		 * @inheritDoc
+		 *
+		 * @default true
+		 */
+		public function get useVirtualLayout():Boolean
+		{
+			return this._useVirtualLayout;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set useVirtualLayout(value:Boolean):void
+		{
+			if(this._useVirtualLayout == value)
+			{
+				return;
+			}
+			this._useVirtualLayout = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _hasVariableItemDimensions:Boolean = false;
+
+		/**
+		 * When the layout is virtualized, and this value is true, the items may
+		 * have variable height values. If false, the items will all share the
+		 * same height value with the typical item.
+		 *
+		 * @default false
+		 */
+		public function get hasVariableItemDimensions():Boolean
+		{
+			return this._hasVariableItemDimensions;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set hasVariableItemDimensions(value:Boolean):void
+		{
+			if(this._hasVariableItemDimensions == value)
+			{
+				return;
+			}
+			this._hasVariableItemDimensions = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _beforeVirtualizedItemCount:int = 0;
+
+		/**
+		 * @inheritDoc
+		 */
+		public function get beforeVirtualizedItemCount():int
+		{
+			return this._beforeVirtualizedItemCount;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set beforeVirtualizedItemCount(value:int):void
+		{
+			if(this._beforeVirtualizedItemCount == value)
+			{
+				return;
+			}
+			this._beforeVirtualizedItemCount = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _afterVirtualizedItemCount:int = 0;
+
+		/**
+		 * @inheritDoc
+		 */
+		public function get afterVirtualizedItemCount():int
+		{
+			return this._afterVirtualizedItemCount;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set afterVirtualizedItemCount(value:int):void
+		{
+			if(this._afterVirtualizedItemCount == value)
+			{
+				return;
+			}
+			this._afterVirtualizedItemCount = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _typicalItem:DisplayObject;
+
+		/**
+		 * @inheritDoc
+		 *
+		 * @see #resetTypicalItemDimensionsOnMeasure
+		 * @see #typicalItemWidth
+		 * @see #typicalItemHeight
+		 */
+		public function get typicalItem():DisplayObject
+		{
+			return this._typicalItem;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set typicalItem(value:DisplayObject):void
+		{
+			if(this._typicalItem == value)
+			{
+				return;
+			}
+			this._typicalItem = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _resetTypicalItemDimensionsOnMeasure:Boolean = false;
+
+		/**
+		 * If set to <code>true</code>, the width and height of the
+		 * <code>typicalItem</code> will be reset to <code>typicalItemWidth</code>
+		 * and <code>typicalItemHeight</code>, respectively, whenever the
+		 * typical item needs to be measured. The measured dimensions of the
+		 * typical item are used to fill in the blanks of a virtualized layout
+		 * for virtual items that don't have their own display objects to
+		 * measure yet.
+		 *
+		 * @default false
+		 *
+		 * @see #typicalItemWidth
+		 * @see #typicalItemHeight
+		 * @see #typicalItem
+		 */
+		public function get resetTypicalItemDimensionsOnMeasure():Boolean
+		{
+			return this._resetTypicalItemDimensionsOnMeasure;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set resetTypicalItemDimensionsOnMeasure(value:Boolean):void
+		{
+			if(this._resetTypicalItemDimensionsOnMeasure == value)
+			{
+				return;
+			}
+			this._resetTypicalItemDimensionsOnMeasure = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _typicalItemWidth:Number = NaN;
+
+		/**
+		 * Used to reset the width, in pixels, of the <code>typicalItem</code>
+		 * for measurement. The measured dimensions of the typical item are used
+		 * to fill in the blanks of a virtualized layout for virtual items that
+		 * don't have their own display objects to measure yet.
+		 *
+		 * <p>This value is only used when <code>resetTypicalItemDimensionsOnMeasure</code>
+		 * is set to <code>true</code>. If <code>resetTypicalItemDimensionsOnMeasure</code>
+		 * is set to <code>false</code>, this value will be ignored and the
+		 * <code>typicalItem</code> dimensions will not be reset before
+		 * measurement.</p>
+		 *
+		 * <p>If <code>typicalItemWidth</code> is set to <code>NaN</code>, the
+		 * typical item will auto-size itself to its preferred width. If you
+		 * pass a valid <code>Number</code> value, the typical item's width will
+		 * be set to a fixed size. May be used in combination with
+		 * <code>typicalItemHeight</code>.</p>
+		 *
+		 * @default NaN
+		 *
+		 * @see #resetTypicalItemDimensionsOnMeasure
+		 * @see #typicalItemHeight
+		 * @see #typicalItem
+		 */
+		public function get typicalItemWidth():Number
+		{
+			return this._typicalItemWidth;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set typicalItemWidth(value:Number):void
+		{
+			if(this._typicalItemWidth == value)
+			{
+				return;
+			}
+			this._typicalItemWidth = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @private
+		 */
+		protected var _typicalItemHeight:Number = NaN;
+
+		/**
+		 * Used to reset the height, in pixels, of the <code>typicalItem</code>
+		 * for measurement. The measured dimensions of the typical item are used
+		 * to fill in the blanks of a virtualized layout for virtual items that
+		 * don't have their own display objects to measure yet.
+		 *
+		 * <p>This value is only used when <code>resetTypicalItemDimensionsOnMeasure</code>
+		 * is set to <code>true</code>. If <code>resetTypicalItemDimensionsOnMeasure</code>
+		 * is set to <code>false</code>, this value will be ignored and the
+		 * <code>typicalItem</code> dimensions will not be reset before
+		 * measurement.</p>
+		 *
+		 * <p>If <code>typicalItemHeight</code> is set to <code>NaN</code>, the
+		 * typical item will auto-size itself to its preferred height. If you
+		 * pass a valid <code>Number</code> value, the typical item's height will
+		 * be set to a fixed size. May be used in combination with
+		 * <code>typicalItemWidth</code>.</p>
+		 *
+		 * @default NaN
+		 *
+		 * @see #resetTypicalItemDimensionsOnMeasure
+		 * @see #typicalItemWidth
+		 * @see #typicalItem
+		 */
+		public function get typicalItemHeight():Number
+		{
+			return this._typicalItemHeight;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set typicalItemHeight(value:Number):void
+		{
+			if(this._typicalItemHeight == value)
+			{
+				return;
+			}
+			this._typicalItemHeight = value;
+			this.dispatchEventWith(Event.CHANGE);
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function get requiresLayoutOnScroll():Boolean
+		{
+			throw new AbstractMethodError();
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function layout(items:Vector.<DisplayObject>, viewPortBounds:ViewPortBounds = null, result:LayoutBoundsResult = null):LayoutBoundsResult
+		{
+			throw new AbstractMethodError();
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function measureViewPort(itemCount:int, viewPortBounds:ViewPortBounds = null, result:Point = null):Point
+		{
+			throw new AbstractMethodError();
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function resetVariableVirtualCache():void
+		{
+			this._cache.length = 0;
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function resetVariableVirtualCacheAtIndex(index:int, item:DisplayObject = null):void
+		{
+			delete this._cache[index];
+			if(item)
+			{
+				this._cache[index] = item.height;
+				this.dispatchEventWith(Event.CHANGE);
+			}
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function addToVariableVirtualCacheAtIndex(index:int, item:DisplayObject = null):void
+		{
+			var heightValue:* = item ? item.height : undefined;
+			this._cache.insertAt(index, heightValue);
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function removeFromVariableVirtualCacheAtIndex(index:int):void
+		{
+			this._cache.removeAt(index);
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function getVisibleIndicesAtScrollPosition(scrollX:Number, scrollY:Number, width:Number, height:Number, itemCount:int, result:Vector.<int> = null):Vector.<int>
+		{
+			throw new AbstractMethodError();
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function getNearestScrollPositionForIndex(index:int, scrollX:Number, scrollY:Number, items:Vector.<DisplayObject>,
+			x:Number, y:Number, width:Number, height:Number, result:Point = null):Point
+		{
+			throw new AbstractMethodError();
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function calculateNavigationDestination(items:Vector.<DisplayObject>, index:int, keyCode:uint, bounds:LayoutBoundsResult):int
+		{
+			throw new AbstractMethodError();
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function getScrollPositionForIndex(index:int, items:Vector.<DisplayObject>, x:Number, y:Number, width:Number, height:Number, result:Point = null):Point
+		{
+			throw new AbstractMethodError();
+		}
+
+
+	}
+}

--- a/source/feathers/layout/VerticalLayout.as
+++ b/source/feathers/layout/VerticalLayout.as
@@ -11,8 +11,6 @@ package feathers.layout
 	import flash.geom.Point;
 	import flash.ui.Keyboard;
 	
-	import mx.effects.easing.Linear;
-	
 	import feathers.core.IFeathersControl;
 	import feathers.core.IMeasureDisplayObject;
 	import feathers.core.IValidating;

--- a/source/feathers/layout/VerticalLayout.as
+++ b/source/feathers/layout/VerticalLayout.as
@@ -7,72 +7,21 @@ accordance with the terms of the accompanying license agreement.
 */
 package feathers.layout
 {
-	import feathers.core.IFeathersControl;
-	import feathers.core.IMeasureDisplayObject;
-	import feathers.core.IValidating;
-
 	import flash.errors.IllegalOperationError;
 	import flash.geom.Point;
 	import flash.ui.Keyboard;
-
-	import starling.display.DisplayObject;
-
+	
+	import mx.effects.easing.Linear;
+	
+	import feathers.core.IFeathersControl;
+	import feathers.core.IMeasureDisplayObject;
+	import feathers.core.IValidating;
+	
 	import starling.display.DisplayObject;
 	import starling.display.DisplayObjectContainer;
 	import starling.events.Event;
 	import starling.events.EventDispatcher;
 	import starling.utils.Pool;
-
-	/**
-	 * Dispatched when a property of the layout changes, indicating that a
-	 * redraw is probably needed.
-	 *
-	 * <p>The properties of the event object have the following values:</p>
-	 * <table class="innertable">
-	 * <tr><th>Property</th><th>Value</th></tr>
-	 * <tr><td><code>bubbles</code></td><td>false</td></tr>
-	 * <tr><td><code>currentTarget</code></td><td>The Object that defines the
-	 *   event listener that handles the event. For example, if you use
-	 *   <code>myButton.addEventListener()</code> to register an event listener,
-	 *   myButton is the value of the <code>currentTarget</code>.</td></tr>
-	 * <tr><td><code>data</code></td><td>null</td></tr>
-	 * <tr><td><code>target</code></td><td>The Object that dispatched the event;
-	 *   it is not always the Object listening for the event. Use the
-	 *   <code>currentTarget</code> property to always access the Object
-	 *   listening for the event.</td></tr>
-	 * </table>
-	 *
-	 * @eventType starling.events.Event.CHANGE
-	 */
-	[Event(name="change",type="starling.events.Event")]
-
-	/**
-	 * Dispatched when the layout would like to adjust the container's scroll
-	 * position. Typically, this is used when the virtual dimensions of an item
-	 * differ from its real dimensions. This event allows the container to
-	 * adjust scrolling so that it appears smooth, without jarring jumps or
-	 * shifts when an item resizes.
-	 *
-	 * <p>The properties of the event object have the following values:</p>
-	 * <table class="innertable">
-	 * <tr><th>Property</th><th>Value</th></tr>
-	 * <tr><td><code>bubbles</code></td><td>false</td></tr>
-	 * <tr><td><code>currentTarget</code></td><td>The Object that defines the
-	 *   event listener that handles the event. For example, if you use
-	 *   <code>myButton.addEventListener()</code> to register an event listener,
-	 *   myButton is the value of the <code>currentTarget</code>.</td></tr>
-	 * <tr><td><code>data</code></td><td>A <code>flash.geom.Point</code> object
-	 *   representing how much the scroll position should be adjusted in both
-	 *   horizontal and vertical directions. Measured in pixels.</td></tr>
-	 * <tr><td><code>target</code></td><td>The Object that dispatched the event;
-	 *   it is not always the Object listening for the event. Use the
-	 *   <code>currentTarget</code> property to always access the Object
-	 *   listening for the event.</td></tr>
-	 * </table>
-	 *
-	 * @eventType starling.events.Event.SCROLL
-	 */
-	[Event(name="scroll",type="starling.events.Event")]
 
 	/**
 	 * Positions items from top to bottom in a single column.
@@ -81,7 +30,7 @@ package feathers.layout
 	 *
 	 * @productversion Feathers 1.0.0
 	 */
-	public class VerticalLayout extends EventDispatcher implements IVariableVirtualLayout, ITrimmedVirtualLayout, IGroupedLayout
+	public class VerticalLayout extends LinearLayout implements IVariableVirtualLayout, ITrimmedVirtualLayout, IGroupedLayout
 	{
 		[Deprecated(replacement="feathers.layout.VerticalAlign.TOP",since="3.0.0")]
 		/**
@@ -178,323 +127,6 @@ package feathers.layout
 		/**
 		 * @private
 		 */
-		protected var _heightCache:Array = [];
-
-		/**
-		 * @private
-		 */
-		protected var _discoveredItemsCache:Vector.<DisplayObject> = new <DisplayObject>[];
-
-		/**
-		 * @private
-		 */
-		protected var _gap:Number = 0;
-
-		/**
-		 * The space, in pixels, between items.
-		 *
-		 * @default 0
-		 */
-		public function get gap():Number
-		{
-			return this._gap;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set gap(value:Number):void
-		{
-			if(this._gap == value)
-			{
-				return;
-			}
-			this._gap = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _firstGap:Number = NaN;
-
-		/**
-		 * The space, in pixels, between the first and second items. If the
-		 * value of <code>firstGap</code> is <code>NaN</code>, the value of the
-		 * <code>gap</code> property will be used instead.
-		 *
-		 * @default NaN
-		 */
-		public function get firstGap():Number
-		{
-			return this._firstGap;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set firstGap(value:Number):void
-		{
-			if(this._firstGap == value)
-			{
-				return;
-			}
-			this._firstGap = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _lastGap:Number = NaN;
-
-		/**
-		 * The space, in pixels, between the last and second to last items. If
-		 * the value of <code>lastGap</code> is <code>NaN</code>, the value of
-		 * the <code>gap</code> property will be used instead.
-		 *
-		 * @default NaN
-		 */
-		public function get lastGap():Number
-		{
-			return this._lastGap;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set lastGap(value:Number):void
-		{
-			if(this._lastGap == value)
-			{
-				return;
-			}
-			this._lastGap = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * Quickly sets all padding properties to the same value. The
-		 * <code>padding</code> getter always returns the value of
-		 * <code>paddingTop</code>, but the other padding values may be
-		 * different.
-		 *
-		 * @default 0
-		 *
-		 * @see #paddingTop
-		 * @see #paddingRight
-		 * @see #paddingBottom
-		 * @see #paddingLeft
-		 */
-		public function get padding():Number
-		{
-			return this._paddingTop;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set padding(value:Number):void
-		{
-			this.paddingTop = value;
-			this.paddingRight = value;
-			this.paddingBottom = value;
-			this.paddingLeft = value;
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _paddingTop:Number = 0;
-
-		/**
-		 * The space, in pixels, that appears on top, before the first item.
-		 *
-		 * @default 0
-		 */
-		public function get paddingTop():Number
-		{
-			return this._paddingTop;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set paddingTop(value:Number):void
-		{
-			if(this._paddingTop == value)
-			{
-				return;
-			}
-			this._paddingTop = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _paddingRight:Number = 0;
-
-		/**
-		 * The minimum space, in pixels, to the right of the items.
-		 *
-		 * @default 0
-		 */
-		public function get paddingRight():Number
-		{
-			return this._paddingRight;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set paddingRight(value:Number):void
-		{
-			if(this._paddingRight == value)
-			{
-				return;
-			}
-			this._paddingRight = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _paddingBottom:Number = 0;
-
-		/**
-		 * The space, in pixels, that appears on the bottom, after the last
-		 * item.
-		 *
-		 * @default 0
-		 */
-		public function get paddingBottom():Number
-		{
-			return this._paddingBottom;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set paddingBottom(value:Number):void
-		{
-			if(this._paddingBottom == value)
-			{
-				return;
-			}
-			this._paddingBottom = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _paddingLeft:Number = 0;
-
-		/**
-		 * The minimum space, in pixels, to the left of the items.
-		 *
-		 * @default 0
-		 */
-		public function get paddingLeft():Number
-		{
-			return this._paddingLeft;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set paddingLeft(value:Number):void
-		{
-			if(this._paddingLeft == value)
-			{
-				return;
-			}
-			this._paddingLeft = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-
-		/**
-		 * @private
-		 */
-		protected var _verticalAlign:String = VerticalAlign.TOP;
-
-		[Inspectable(type="String",enumeration="top,middle,bottom")]
-		/**
-		 * If the total item height is less than the bounds, the positions of
-		 * the items can be aligned vertically.
-		 *
-		 * @default feathers.layout.VerticalAlign.TOP
-		 *
-		 * @see feathers.layout.VerticalAlign#TOP
-		 * @see feathers.layout.VerticalAlign#MIDDLE
-		 * @see feathers.layout.VerticalAlign#BOTTOM
-		 */
-		public function get verticalAlign():String
-		{
-			return this._verticalAlign;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set verticalAlign(value:String):void
-		{
-			if(this._verticalAlign == value)
-			{
-				return;
-			}
-			this._verticalAlign = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _horizontalAlign:String = HorizontalAlign.LEFT;
-
-		[Inspectable(type="String",enumeration="left,center,right,justify")]
-		/**
-		 * The alignment of the items horizontally, on the x-axis.
-		 *
-		 * <p>If the <code>horizontalAlign</code> property is set to
-		 * <code>VerticalLayout.HorizontalAlign.JUSTIFY</code>, the
-		 * <code>width</code>, <code>minWidth</code>, and <code>maxWidth</code>
-		 * properties of the items may be changed, and their original values
-		 * ignored by the layout. In this situation, if the width needs to be
-		 * constrained, the <code>width</code>, <code>minWidth</code>, or
-		 * <code>maxWidth</code> properties should instead be set on the parent
-		 * container using the layout.</p>
-		 *
-		 * @default feathers.layout.HorizontalAlign.LEFT
-		 *
-		 * @see feathers.layout.HorizontalAlign#LEFT
-		 * @see feathers.layout.HorizontalAlign#CENTER
-		 * @see feathers.layout.HorizontalAlign#RIGHT
-		 * @see feathers.layout.HorizontalAlign#JUSTIFY
-		 */
-		public function get horizontalAlign():String
-		{
-			return this._horizontalAlign;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set horizontalAlign(value:String):void
-		{
-			if(this._horizontalAlign == value)
-			{
-				return;
-			}
-			this._horizontalAlign = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-		/**
-		 * @private
-		 */
 		protected var _stickyHeader:Boolean = false;
 
 		/**
@@ -547,64 +179,6 @@ package feathers.layout
 				return;
 			}
 			this._headerIndices = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _useVirtualLayout:Boolean = true;
-
-		/**
-		 * @inheritDoc
-		 *
-		 * @default true
-		 */
-		public function get useVirtualLayout():Boolean
-		{
-			return this._useVirtualLayout;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set useVirtualLayout(value:Boolean):void
-		{
-			if(this._useVirtualLayout == value)
-			{
-				return;
-			}
-			this._useVirtualLayout = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _hasVariableItemDimensions:Boolean = false;
-
-		/**
-		 * When the layout is virtualized, and this value is true, the items may
-		 * have variable height values. If false, the items will all share the
-		 * same height value with the typical item.
-		 *
-		 * @default false
-		 */
-		public function get hasVariableItemDimensions():Boolean
-		{
-			return this._hasVariableItemDimensions;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set hasVariableItemDimensions(value:Boolean):void
-		{
-			if(this._hasVariableItemDimensions == value)
-			{
-				return;
-			}
-			this._hasVariableItemDimensions = value;
 			this.dispatchEventWith(Event.CHANGE);
 		}
 
@@ -719,220 +293,6 @@ package feathers.layout
 		/**
 		 * @private
 		 */
-		protected var _beforeVirtualizedItemCount:int = 0;
-
-		/**
-		 * @inheritDoc
-		 */
-		public function get beforeVirtualizedItemCount():int
-		{
-			return this._beforeVirtualizedItemCount;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set beforeVirtualizedItemCount(value:int):void
-		{
-			if(this._beforeVirtualizedItemCount == value)
-			{
-				return;
-			}
-			this._beforeVirtualizedItemCount = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _afterVirtualizedItemCount:int = 0;
-
-		/**
-		 * @inheritDoc
-		 */
-		public function get afterVirtualizedItemCount():int
-		{
-			return this._afterVirtualizedItemCount;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set afterVirtualizedItemCount(value:int):void
-		{
-			if(this._afterVirtualizedItemCount == value)
-			{
-				return;
-			}
-			this._afterVirtualizedItemCount = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _typicalItem:DisplayObject;
-
-		/**
-		 * @inheritDoc
-		 *
-		 * @see #resetTypicalItemDimensionsOnMeasure
-		 * @see #typicalItemWidth
-		 * @see #typicalItemHeight
-		 */
-		public function get typicalItem():DisplayObject
-		{
-			return this._typicalItem;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set typicalItem(value:DisplayObject):void
-		{
-			if(this._typicalItem == value)
-			{
-				return;
-			}
-			this._typicalItem = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _resetTypicalItemDimensionsOnMeasure:Boolean = false;
-
-		/**
-		 * If set to <code>true</code>, the width and height of the
-		 * <code>typicalItem</code> will be reset to <code>typicalItemWidth</code>
-		 * and <code>typicalItemHeight</code>, respectively, whenever the
-		 * typical item needs to be measured. The measured dimensions of the
-		 * typical item are used to fill in the blanks of a virtualized layout
-		 * for virtual items that don't have their own display objects to
-		 * measure yet.
-		 *
-		 * @default false
-		 *
-		 * @see #typicalItemWidth
-		 * @see #typicalItemHeight
-		 * @see #typicalItem
-		 */
-		public function get resetTypicalItemDimensionsOnMeasure():Boolean
-		{
-			return this._resetTypicalItemDimensionsOnMeasure;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set resetTypicalItemDimensionsOnMeasure(value:Boolean):void
-		{
-			if(this._resetTypicalItemDimensionsOnMeasure == value)
-			{
-				return;
-			}
-			this._resetTypicalItemDimensionsOnMeasure = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _typicalItemWidth:Number = NaN;
-
-		/**
-		 * Used to reset the width, in pixels, of the <code>typicalItem</code>
-		 * for measurement. The measured dimensions of the typical item are used
-		 * to fill in the blanks of a virtualized layout for virtual items that
-		 * don't have their own display objects to measure yet.
-		 *
-		 * <p>This value is only used when <code>resetTypicalItemDimensionsOnMeasure</code>
-		 * is set to <code>true</code>. If <code>resetTypicalItemDimensionsOnMeasure</code>
-		 * is set to <code>false</code>, this value will be ignored and the
-		 * <code>typicalItem</code> dimensions will not be reset before
-		 * measurement.</p>
-		 *
-		 * <p>If <code>typicalItemWidth</code> is set to <code>NaN</code>, the
-		 * typical item will auto-size itself to its preferred width. If you
-		 * pass a valid <code>Number</code> value, the typical item's width will
-		 * be set to a fixed size. May be used in combination with
-		 * <code>typicalItemHeight</code>.</p>
-		 *
-		 * @default NaN
-		 *
-		 * @see #resetTypicalItemDimensionsOnMeasure
-		 * @see #typicalItemHeight
-		 * @see #typicalItem
-		 */
-		public function get typicalItemWidth():Number
-		{
-			return this._typicalItemWidth;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set typicalItemWidth(value:Number):void
-		{
-			if(this._typicalItemWidth == value)
-			{
-				return;
-			}
-			this._typicalItemWidth = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
-		protected var _typicalItemHeight:Number = NaN;
-
-		/**
-		 * Used to reset the height, in pixels, of the <code>typicalItem</code>
-		 * for measurement. The measured dimensions of the typical item are used
-		 * to fill in the blanks of a virtualized layout for virtual items that
-		 * don't have their own display objects to measure yet.
-		 *
-		 * <p>This value is only used when <code>resetTypicalItemDimensionsOnMeasure</code>
-		 * is set to <code>true</code>. If <code>resetTypicalItemDimensionsOnMeasure</code>
-		 * is set to <code>false</code>, this value will be ignored and the
-		 * <code>typicalItem</code> dimensions will not be reset before
-		 * measurement.</p>
-		 *
-		 * <p>If <code>typicalItemHeight</code> is set to <code>NaN</code>, the
-		 * typical item will auto-size itself to its preferred height. If you
-		 * pass a valid <code>Number</code> value, the typical item's height will
-		 * be set to a fixed size. May be used in combination with
-		 * <code>typicalItemWidth</code>.</p>
-		 *
-		 * @default NaN
-		 *
-		 * @see #resetTypicalItemDimensionsOnMeasure
-		 * @see #typicalItemWidth
-		 * @see #typicalItem
-		 */
-		public function get typicalItemHeight():Number
-		{
-			return this._typicalItemHeight;
-		}
-
-		/**
-		 * @private
-		 */
-		public function set typicalItemHeight(value:Number):void
-		{
-			if(this._typicalItemHeight == value)
-			{
-				return;
-			}
-			this._typicalItemHeight = value;
-			this.dispatchEventWith(Event.CHANGE);
-		}
-
-		/**
-		 * @private
-		 */
 		protected var _scrollPositionVerticalAlign:String = VerticalAlign.MIDDLE;
 
 		[Inspectable(type="String",enumeration="top,middle,bottom")]
@@ -995,7 +355,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function get requiresLayoutOnScroll():Boolean
+		public override function get requiresLayoutOnScroll():Boolean
 		{
 			return this._useVirtualLayout ||
 				(this._headerIndices && this._stickyHeader); //the header needs to stick!
@@ -1004,7 +364,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function layout(items:Vector.<DisplayObject>, viewPortBounds:ViewPortBounds = null, result:LayoutBoundsResult = null):LayoutBoundsResult
+		public override function layout(items:Vector.<DisplayObject>, viewPortBounds:ViewPortBounds = null, result:LayoutBoundsResult = null):LayoutBoundsResult
 		{
 			//this function is very long because it may be called every frame,
 			//in some situations. testing revealed that splitting this function
@@ -1184,7 +544,7 @@ package feathers.layout
 
 				if(this._useVirtualLayout && this._hasVariableItemDimensions)
 				{
-					var cachedHeight:Number = this._heightCache[iNormalized];
+					var cachedHeight:Number = this._cache[iNormalized];
 				}
 				if(this._useVirtualLayout && !item)
 				{
@@ -1240,7 +600,7 @@ package feathers.layout
 								//the container that the virtualized layout has
 								//changed, and it the view port may need to be
 								//re-measured.
-								this._heightCache[iNormalized] = itemHeight;
+								this._cache[iNormalized] = itemHeight;
 
 								//attempt to adjust the scroll position so that
 								//it looks like we're scrolling smoothly after
@@ -1529,7 +889,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function measureViewPort(itemCount:int, viewPortBounds:ViewPortBounds = null, result:Point = null):Point
+		public override function measureViewPort(itemCount:int, viewPortBounds:ViewPortBounds = null, result:Point = null):Point
 		{
 			if(!result)
 			{
@@ -1578,7 +938,7 @@ package feathers.layout
 				{
 					for(var i:int = 0; i < itemCount; i++)
 					{
-						var cachedHeight:Number = this._heightCache[i];
+						var cachedHeight:Number = this._cache[i];
 						if(cachedHeight !== cachedHeight) //isNaN
 						{
 							positionY += calculatedTypicalItemHeight + this._gap;
@@ -1658,45 +1018,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function resetVariableVirtualCache():void
-		{
-			this._heightCache.length = 0;
-		}
-
-		/**
-		 * @inheritDoc
-		 */
-		public function resetVariableVirtualCacheAtIndex(index:int, item:DisplayObject = null):void
-		{
-			delete this._heightCache[index];
-			if(item)
-			{
-				this._heightCache[index] = item.height;
-				this.dispatchEventWith(Event.CHANGE);
-			}
-		}
-
-		/**
-		 * @inheritDoc
-		 */
-		public function addToVariableVirtualCacheAtIndex(index:int, item:DisplayObject = null):void
-		{
-			var heightValue:* = item ? item.height : undefined;
-			this._heightCache.insertAt(index, heightValue);
-		}
-
-		/**
-		 * @inheritDoc
-		 */
-		public function removeFromVariableVirtualCacheAtIndex(index:int):void
-		{
-			this._heightCache.removeAt(index);
-		}
-
-		/**
-		 * @inheritDoc
-		 */
-		public function getVisibleIndicesAtScrollPosition(scrollX:Number, scrollY:Number, width:Number, height:Number, itemCount:int, result:Vector.<int> = null):Vector.<int>
+		public override function getVisibleIndicesAtScrollPosition(scrollX:Number, scrollY:Number, width:Number, height:Number, itemCount:int, result:Vector.<int> = null):Vector.<int>
 		{
 			if(result)
 			{
@@ -1835,7 +1157,7 @@ package feathers.layout
 				{
 					gap = this._lastGap;
 				}
-				var cachedHeight:Number = this._heightCache[i];
+				var cachedHeight:Number = this._cache[i];
 				if(cachedHeight !== cachedHeight) //isNaN
 				{
 					var itemHeight:Number = calculatedTypicalItemHeight;
@@ -1936,7 +1258,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function getNearestScrollPositionForIndex(index:int, scrollX:Number, scrollY:Number, items:Vector.<DisplayObject>,
+		public override function getNearestScrollPositionForIndex(index:int, scrollX:Number, scrollY:Number, items:Vector.<DisplayObject>,
 			x:Number, y:Number, width:Number, height:Number, result:Point = null):Point
 		{
 			var point:Point = Pool.getPoint();
@@ -1950,7 +1272,7 @@ package feathers.layout
 			{
 				if(this._hasVariableItemDimensions)
 				{
-					var itemHeight:Number = this._heightCache[index];
+					var itemHeight:Number = this._cache[index];
 					if(itemHeight !== itemHeight) //isNaN
 					{
 						itemHeight = this._typicalItem.height;
@@ -1999,7 +1321,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function calculateNavigationDestination(items:Vector.<DisplayObject>, index:int, keyCode:uint, bounds:LayoutBoundsResult):int
+		public override function calculateNavigationDestination(items:Vector.<DisplayObject>, index:int, keyCode:uint, bounds:LayoutBoundsResult):int
 		{
 			var itemArrayCount:int = items.length;
 			var itemCount:int = itemArrayCount + this._beforeVirtualizedItemCount + this._afterVirtualizedItemCount;
@@ -2039,7 +1361,7 @@ package feathers.layout
 					var iNormalized:int = i + indexOffset;
 					if(this._useVirtualLayout && this._hasVariableItemDimensions)
 					{
-						var cachedHeight:Number = this._heightCache[i];
+						var cachedHeight:Number = this._cache[i];
 					}
 					if(iNormalized < 0 || iNormalized >= itemArrayCount)
 					{
@@ -2092,7 +1414,7 @@ package feathers.layout
 					iNormalized = i + indexOffset;
 					if(this._useVirtualLayout && this._hasVariableItemDimensions)
 					{
-						cachedHeight = this._heightCache[i];
+						cachedHeight = this._cache[i];
 					}
 					if(iNormalized < 0 || iNormalized >= itemArrayCount)
 					{
@@ -2174,7 +1496,7 @@ package feathers.layout
 		/**
 		 * @inheritDoc
 		 */
-		public function getScrollPositionForIndex(index:int, items:Vector.<DisplayObject>, x:Number, y:Number, width:Number, height:Number, result:Point = null):Point
+		public override function getScrollPositionForIndex(index:int, items:Vector.<DisplayObject>, x:Number, y:Number, width:Number, height:Number, result:Point = null):Point
 		{
 			var point:Point = Pool.getPoint();
 			this.calculateScrollRangeOfIndex(index, items, x, y, width, height, point);
@@ -2187,7 +1509,7 @@ package feathers.layout
 			{
 				if(this._hasVariableItemDimensions)
 				{
-					var itemHeight:Number = this._heightCache[index];
+					var itemHeight:Number = this._cache[index];
 					if(itemHeight !== itemHeight) //isNaN
 					{
 						itemHeight = this._typicalItem.height;
@@ -2678,7 +2000,7 @@ package feathers.layout
 				}
 				if(this._useVirtualLayout && this._hasVariableItemDimensions)
 				{
-					var cachedHeight:Number = this._heightCache[iNormalized];
+					var cachedHeight:Number = this._cache[iNormalized];
 				}
 				if(this._useVirtualLayout && !item)
 				{
@@ -2701,7 +2023,7 @@ package feathers.layout
 						{
 							if(itemHeight != cachedHeight)
 							{
-								this._heightCache[iNormalized] = itemHeight;
+								this._cache[iNormalized] = itemHeight;
 								this.dispatchEventWith(Event.CHANGE);
 							}
 						}


### PR DESCRIPTION
This commit adds a new base class for `HorizontalLayout` and `VerticalLayout` called `LinearLayout`. This allows us to move _more than 600 lines_ of duplicated code out of `HorizontalLayout`/`VerticalLayout` and into the new base class. It also gives us slightly more flexibility with polymorphism.