### PR TITLE
TextFieldTextRenderer: fix last line getting lost (Feathers 2.3)

### DIFF
--- a/source/feathers/controls/text/TextFieldTextRenderer.as
+++ b/source/feathers/controls/text/TextFieldTextRenderer.as
@@ -1524,7 +1524,7 @@ package feathers.controls.text
 			var newHeight:Number = this.explicitHeight;
 			if(needsHeight)
 			{
-				newHeight = (this.textField.height / scaleFactor) - gutterDimensionsOffset;
+				newHeight = Math.ceil(this.textField.height / scaleFactor) - gutterDimensionsOffset;
 				if(newHeight < this._minHeight)
 				{
 					newHeight = this._minHeight;


### PR DESCRIPTION
Feathers 2.x has a bug with TextFieldTextRenderer, where the last line of a multi-line Label sometimes is not rendered. This occurs when the calculated height of the text is a fraction. This issue is resolved by rounding up the height to the nearest integer.

Although Feathers 2.3 is no longer in active development, this fix is critical for legacy products which rely on Feathers 2.3.