### PR TITLE
Fixes error in feathers.utils.touch.LongPress

### DIFF
--- a/source/feathers/utils/touch/LongPress.as
+++ b/source/feathers/utils/touch/LongPress.as
@@ -90,6 +90,7 @@ package feathers.utils.touch
 			if(this._target)
 			{
 				this._target.removeEventListener(TouchEvent.TOUCH, target_touchHandler);
+				this._target.removeEventListener(Event.ENTER_FRAME, target_enterFrameHandler);
 			}
 			this._target = value;
 			if(this._target)


### PR DESCRIPTION
Fixes null object reference error on `feathers.utils.touch.LongPress.target_enterFrameHandler()` when target is set to null during a touch