### PR TITLE
FeathersControl.visible now checks corresponding effect context

### DIFF
--- a/source/feathers/core/FeathersControl.as
+++ b/source/feathers/core/FeathersControl.as
@@ -538,20 +538,22 @@ package feathers.core
 		{
 			this._hideEffect = value;
 		}
+		
+		/**
+		 * @private
+		 */
+		protected var _pendingVisibleValue:Boolean = true;
 
 		/**
 		 * @private
 		 */
 		override public function set visible(value:Boolean):void
 		{
-			if(value == true && this._showEffectContext !== null)
+			if(value == this._pendingVisibleValue)
 			{
 				return;
 			}
-			if(value == false && this._hideEffectContext !== null)
-			{
-				return;
-			}
+			this._pendingVisibleValue = value;
 			if(this._suspendEffectsCount == 0 && this._hideEffectContext !== null)
 			{
 				this._hideEffectContext.interrupt();
@@ -562,9 +564,9 @@ package feathers.core
 				this._showEffectContext.interrupt();
 				this._showEffectContext = null;
 			}
-			if(value)
+			if(this._pendingVisibleValue)
 			{
-				super.visible = value;
+				super.visible = this._pendingVisibleValue;
 				if(this.isCreated && this._suspendEffectsCount == 0 && this._showEffect !== null && this.stage !== null)
 				{
 					this._showEffectContext = IEffectContext(this._showEffect(this));
@@ -576,7 +578,7 @@ package feathers.core
 			{
 				if(!this.isCreated || this._suspendEffectsCount > 0 || this._hideEffect === null || this.stage === null)
 				{
-					super.visible = value;
+					super.visible = this._pendingVisibleValue;
 				}
 				else
 				{
@@ -3693,7 +3695,7 @@ package feathers.core
 			if(!stopped)
 			{
 				this.suspendEffects();
-				this.visible = false;
+				this.visible = _pendingVisibleValue;
 				this.resumeEffects();
 			}
 		}

--- a/source/feathers/core/FeathersControl.as
+++ b/source/feathers/core/FeathersControl.as
@@ -544,7 +544,11 @@ package feathers.core
 		 */
 		override public function set visible(value:Boolean):void
 		{
-			if(super.visible == value)
+			if(value == true && this._showEffectContext !== null)
+			{
+				return;
+			}
+			if(value == false && this._hideEffectContext !== null)
 			{
 				return;
 			}


### PR DESCRIPTION
I noticed that the commit fixing issue #1787 won't always work as expected. 
For example, hideEffect only sets super.visible to false when it's finished running. If hideEffect is running, setting visible = true will be ignored allowing the effect to continue, and setting to false will interrupt the effect.
I have updated it so that it returns only if the new value's corresponding effect is running. Otherwise it carries on as before. I haven't fully tested this, as I'm running the SDK.